### PR TITLE
feat(parquet): add experimental VECTOR encoding for Arrow FixedSizeList

### DIFF
--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -29,17 +29,18 @@ use crate::arrow::array_reader::row_group_cache::RowGroupCache;
 use crate::arrow::array_reader::row_group_index::RowGroupIndexReader;
 use crate::arrow::array_reader::row_number::RowNumberReader;
 use crate::arrow::array_reader::{
-    ArrayReader, FixedSizeListArrayReader, ListArrayReader, ListViewArrayReader, MapArrayReader,
-    NullArrayReader, PrimitiveArrayReader, RowGroups, StructArrayReader,
-    make_byte_array_dictionary_reader, make_byte_array_reader,
+    ArrayReader, FixedSizeListArrayReader, FixedSizeListVectorArrayReader, ListArrayReader,
+    ListViewArrayReader, MapArrayReader, NullArrayReader, PrimitiveArrayReader, RowGroups,
+    StructArrayReader, make_byte_array_dictionary_reader, make_byte_array_reader,
 };
 use crate::arrow::arrow_reader::DEFAULT_BATCH_SIZE;
 use crate::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 use crate::arrow::schema::{ParquetField, ParquetFieldType, VirtualColumnType};
 use crate::basic::Type as PhysicalType;
+use crate::column::page::{Page, PageIterator, PageMetadata, PageReader};
 use crate::data_type::{BoolType, DoubleType, FloatType, Int32Type, Int64Type, Int96Type};
 use crate::errors::{ParquetError, Result};
-use crate::file::metadata::ParquetMetaData;
+use crate::file::metadata::{ParquetMetaData, RowGroupMetaData};
 use crate::schema::types::{ColumnDescriptor, ColumnPath, Type};
 
 /// Builder for [`CacheOptions`]
@@ -120,6 +121,281 @@ impl<'a> ReaderArgs<'a> {
     /// Used when recursing from a field into one of its children.
     fn with_field(self, field: &'a ParquetField) -> Self {
         Self { field, ..self }
+    }
+}
+
+fn validate_vector_column_chunks<'a>(
+    row_groups: impl IntoIterator<Item = &'a RowGroupMetaData>,
+    col_idx: usize,
+    vector_length: i32,
+) -> Result<()> {
+    if vector_length <= 0 {
+        return Err(general_err!(
+            "VECTOR column {} has invalid vector_length {}",
+            col_idx,
+            vector_length
+        ));
+    }
+    let vector_length = i64::from(vector_length);
+
+    for (row_group_idx, row_group) in row_groups.into_iter().enumerate() {
+        let rows = row_group.num_rows();
+        if rows < 0 {
+            return Err(general_err!(
+                "VECTOR column {} row group {} has negative num_rows {}",
+                col_idx,
+                row_group_idx,
+                rows
+            ));
+        }
+        let expected = rows.checked_mul(vector_length).ok_or_else(|| {
+            general_err!(
+                "VECTOR column {} row group {} num_rows {} * vector_length {} overflows i64",
+                col_idx,
+                row_group_idx,
+                rows,
+                vector_length
+            )
+        })?;
+        let column = row_group.columns().get(col_idx).ok_or_else(|| {
+            general_err!(
+                "VECTOR column {} missing from row group {} metadata",
+                col_idx,
+                row_group_idx
+            )
+        })?;
+        let actual = column.num_values();
+        if actual != expected {
+            return Err(general_err!(
+                "VECTOR column {} row group {} has num_values {}, expected {} (= num_rows {} * vector_length {})",
+                col_idx,
+                row_group_idx,
+                actual,
+                expected,
+                rows,
+                vector_length
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_vector_page_value_count(
+    col_idx: usize,
+    row_group_idx: usize,
+    num_values: usize,
+    num_rows: Option<usize>,
+    vector_length: usize,
+) -> Result<()> {
+    if vector_length == 0 {
+        return Err(general_err!(
+            "VECTOR column {} has invalid vector_length 0",
+            col_idx
+        ));
+    }
+
+    if num_values % vector_length != 0 {
+        return Err(general_err!(
+            "VECTOR column {} row group {} page has num_values {}, which is not a multiple of vector_length {}",
+            col_idx,
+            row_group_idx,
+            num_values,
+            vector_length
+        ));
+    }
+
+    if let Some(num_rows) = num_rows {
+        let expected = num_rows.checked_mul(vector_length).ok_or_else(|| {
+            general_err!(
+                "VECTOR column {} row group {} page num_rows {} * vector_length {} overflows usize",
+                col_idx,
+                row_group_idx,
+                num_rows,
+                vector_length
+            )
+        })?;
+        if num_values != expected {
+            return Err(general_err!(
+                "VECTOR column {} row group {} page has num_values {}, expected {} (= num_rows {} * vector_length {})",
+                col_idx,
+                row_group_idx,
+                num_values,
+                expected,
+                num_rows,
+                vector_length
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_vector_page_metadata(
+    col_idx: usize,
+    row_group_idx: usize,
+    metadata: &PageMetadata,
+    vector_length: usize,
+) -> Result<()> {
+    if metadata.is_dict {
+        return Ok(());
+    }
+
+    if let Some(num_nulls) = metadata.num_nulls.filter(|&n| n != 0) {
+        return Err(general_err!(
+            "VECTOR column {} row group {} page has {} null values; VECTOR pages must be dense",
+            col_idx,
+            row_group_idx,
+            num_nulls
+        ));
+    }
+
+    if let Some(num_values) = metadata.num_levels {
+        validate_vector_page_value_count(
+            col_idx,
+            row_group_idx,
+            num_values,
+            metadata.num_rows,
+            vector_length,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_vector_page(
+    col_idx: usize,
+    row_group_idx: usize,
+    page: &Page,
+    vector_length: usize,
+) -> Result<()> {
+    match page {
+        Page::DataPage { num_values, .. } => validate_vector_page_value_count(
+            col_idx,
+            row_group_idx,
+            *num_values as usize,
+            None,
+            vector_length,
+        ),
+        Page::DataPageV2 {
+            num_values,
+            num_rows,
+            num_nulls,
+            ..
+        } => {
+            if *num_nulls != 0 {
+                return Err(general_err!(
+                    "VECTOR column {} row group {} page has {} null values; VECTOR pages must be dense",
+                    col_idx,
+                    row_group_idx,
+                    num_nulls
+                ));
+            }
+            validate_vector_page_value_count(
+                col_idx,
+                row_group_idx,
+                *num_values as usize,
+                Some(*num_rows as usize),
+                vector_length,
+            )
+        }
+        Page::DictionaryPage { .. } => Ok(()),
+    }
+}
+
+struct VectorPageIterator {
+    inner: Box<dyn PageIterator>,
+    col_idx: usize,
+    vector_length: usize,
+    row_group_idx: usize,
+}
+
+impl VectorPageIterator {
+    fn new(inner: Box<dyn PageIterator>, col_idx: usize, vector_length: usize) -> Self {
+        Self {
+            inner,
+            col_idx,
+            vector_length,
+            row_group_idx: 0,
+        }
+    }
+}
+
+impl Iterator for VectorPageIterator {
+    type Item = Result<Box<dyn PageReader>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row_group_idx = self.row_group_idx;
+        self.row_group_idx += 1;
+        self.inner.next().map(|reader| {
+            reader.map(|inner| {
+                Box::new(VectorPageReader {
+                    inner,
+                    col_idx: self.col_idx,
+                    vector_length: self.vector_length,
+                    row_group_idx,
+                }) as Box<dyn PageReader>
+            })
+        })
+    }
+}
+
+impl PageIterator for VectorPageIterator {}
+
+struct VectorPageReader {
+    inner: Box<dyn PageReader>,
+    col_idx: usize,
+    vector_length: usize,
+    row_group_idx: usize,
+}
+
+impl Iterator for VectorPageReader {
+    type Item = Result<Page>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.get_next_page().transpose()
+    }
+}
+
+impl PageReader for VectorPageReader {
+    fn get_next_page(&mut self) -> Result<Option<Page>> {
+        let page = self.inner.get_next_page()?;
+        if let Some(page) = page.as_ref() {
+            validate_vector_page(self.col_idx, self.row_group_idx, page, self.vector_length)?;
+        }
+        Ok(page)
+    }
+
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>> {
+        let metadata = self.inner.peek_next_page()?;
+        if let Some(metadata) = metadata.as_ref() {
+            validate_vector_page_metadata(
+                self.col_idx,
+                self.row_group_idx,
+                metadata,
+                self.vector_length,
+            )?;
+        }
+        Ok(metadata)
+    }
+
+    fn skip_next_page(&mut self) -> Result<()> {
+        let metadata = self.peek_next_page()?;
+        if metadata
+            .as_ref()
+            .is_some_and(|m| !m.is_dict && m.num_levels.is_none())
+        {
+            // Offset-index metadata may lack page-header counts/nulls; read the
+            // page so VECTOR invariants are validated before skipping it.
+            let _ = self.get_next_page()?;
+            return Ok(());
+        }
+        self.inner.skip_next_page()
+    }
+
+    fn at_record_boundary(&mut self) -> Result<bool> {
+        self.peek_next_page()?;
+        self.inner.at_record_boundary()
     }
 }
 
@@ -367,7 +643,13 @@ impl<'a> ArrayReaderBuilder<'a> {
         let children = field.children().unwrap();
         assert_eq!(children.len(), 1);
 
-        let reader = match self.build_reader(args.with_field(&children[0]))? {
+        let child = &children[0];
+        let vector_length = match &child.field_type {
+            ParquetFieldType::Primitive { vector_length, .. } => *vector_length,
+            _ => None,
+        };
+
+        let reader = match self.build_reader(args.with_field(child))? {
             Some(item_reader) => {
                 let item_type = item_reader.get_data_type().clone();
                 let reader = match &field.arrow_type {
@@ -377,14 +659,40 @@ impl<'a> ArrayReaderBuilder<'a> {
                             size,
                         );
 
-                        Box::new(FixedSizeListArrayReader::new(
-                            item_reader,
-                            size as usize,
-                            data_type,
-                            field.def_level,
-                            field.rep_level,
-                            field.nullable,
-                        )) as _
+                        if let Some(n) = vector_length {
+                            if n != size {
+                                return Err(general_err!(
+                                    "VECTOR column has Parquet vector_length {} but Arrow FixedSizeList size {}",
+                                    n,
+                                    size
+                                ));
+                            }
+                            if field.nullable
+                                || field.def_level != 0
+                                || field.rep_level != 0
+                                || child.def_level != 0
+                                || child.rep_level != 0
+                                || f.is_nullable()
+                            {
+                                return Err(general_err!(
+                                    "reading nullable or nested VECTOR columns is not supported"
+                                ));
+                            }
+                            Box::new(FixedSizeListVectorArrayReader::new(
+                                item_reader,
+                                n as usize,
+                                data_type,
+                            )?) as _
+                        } else {
+                            Box::new(FixedSizeListArrayReader::new(
+                                item_reader,
+                                size as usize,
+                                data_type,
+                                field.def_level,
+                                field.rep_level,
+                                field.nullable,
+                            )) as _
+                        }
                     }
                     _ => unimplemented!(),
                 };
@@ -398,12 +706,13 @@ impl<'a> ArrayReaderBuilder<'a> {
     /// Creates primitive array reader for each primitive type.
     fn build_primitive_reader(&self, args: ReaderArgs<'_>) -> Result<Option<Box<dyn ArrayReader>>> {
         let field = args.field;
-        let (col_idx, primitive_type) = match &field.field_type {
+        let (col_idx, primitive_type, vector_length) = match &field.field_type {
             ParquetFieldType::Primitive {
                 col_idx,
                 primitive_type,
+                vector_length,
             } => match primitive_type.as_ref() {
-                Type::PrimitiveType { .. } => (*col_idx, primitive_type.clone()),
+                Type::PrimitiveType { .. } => (*col_idx, primitive_type.clone(), *vector_length),
                 Type::GroupType { .. } => unreachable!(),
             },
             _ => unreachable!(),
@@ -421,14 +730,32 @@ impl<'a> ArrayReaderBuilder<'a> {
         //
         // None of the readers actually use this field, but it is required for this type,
         // so just stick a placeholder in
-        let column_desc = Arc::new(ColumnDescriptor::new(
+        let column_desc = Arc::new(ColumnDescriptor::new_with_repeated_ancestor_and_vector(
             primitive_type,
             field.def_level,
             field.rep_level,
             ColumnPath::new(vec![]),
+            0,
+            vector_length,
         ));
 
-        let page_iterator = self.row_groups.column_chunks(col_idx)?;
+        let mut page_iterator = self.row_groups.column_chunks(col_idx)?;
+        if let Some(vector_length) = vector_length {
+            validate_vector_column_chunks(self.row_groups.row_groups(), col_idx, vector_length)?;
+            let vector_length = usize::try_from(vector_length).map_err(|_| {
+                general_err!(
+                    "VECTOR column {} has invalid vector_length {}",
+                    col_idx,
+                    vector_length
+                )
+            })?;
+            page_iterator = Box::new(VectorPageIterator::new(
+                page_iterator,
+                col_idx,
+                vector_length,
+            ));
+        }
+
         let arrow_type = Some(field.arrow_type.clone());
 
         // LogicalType::Unknown maps to DataType::Null. In the past it has been assumed
@@ -437,6 +764,15 @@ impl<'a> ArrayReaderBuilder<'a> {
         // used for the NullArrayReader should be irrelevant. It's just needed to read the
         // repetition and definition level data.
         if matches!(arrow_type, Some(DataType::Null)) {
+            // A VECTOR element must never resolve to Null (a dense vector of nulls
+            // is contradictory). Schema conversion already rejects this; guard
+            // here too so the NullArrayReader short-circuit can't bypass the VECTOR
+            // reshape wrapper in the parent FixedSizeList reader.
+            if vector_length.is_some() {
+                return Err(general_err!(
+                    "VECTOR column with a null/unknown element type is not supported"
+                ));
+            }
             let reader = Box::new(NullArrayReader::<Int32Type>::new(
                 page_iterator,
                 column_desc,
@@ -514,6 +850,7 @@ impl<'a> ArrayReaderBuilder<'a> {
                 )?,
             },
         };
+
         Ok(Some(reader))
     }
 
@@ -555,12 +892,17 @@ impl<'a> ArrayReaderBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::arrow::schema::ArrowSchemaConverter;
     use crate::arrow::schema::parquet_to_arrow_schema_and_fields;
     use crate::arrow::schema::virtual_type::RowNumber;
+    use crate::basic::Encoding;
+    use crate::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
     use crate::file::reader::{FileReader, SerializedFileReader};
     use crate::util::test_common::file_util::get_test_file;
-    use arrow::datatypes::Field;
+    use arrow::datatypes::{Field, Schema};
+    use bytes::Bytes;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn test_create_array_reader() {
@@ -591,6 +933,188 @@ mod tests {
         )]));
 
         assert_eq!(array_reader.get_data_type(), &arrow_type);
+    }
+
+    fn vector_row_group(num_rows: i64, num_values: i64) -> RowGroupMetaData {
+        let arrow_schema = Schema::new(vec![Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Float32, false)), 3),
+            false,
+        )]);
+        let schema_descr = Arc::new(
+            ArrowSchemaConverter::new()
+                .with_vector_encoding(true)
+                .convert(&arrow_schema)
+                .unwrap(),
+        );
+        let column = ColumnChunkMetaData::builder(schema_descr.column(0))
+            .set_num_values(num_values)
+            .build()
+            .unwrap();
+        RowGroupMetaData::builder(schema_descr)
+            .set_num_rows(num_rows)
+            .set_column_metadata(vec![column])
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn vector_column_chunk_metadata_must_match_row_count() {
+        let valid = vector_row_group(2, 6);
+        validate_vector_column_chunks([&valid], 0, 3).unwrap();
+
+        let invalid = vector_row_group(2, 5);
+        let err = validate_vector_column_chunks([&invalid], 0, 3)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("num_values 5") && err.contains("expected 6"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_page_metadata_must_match_row_count() {
+        let valid = PageMetadata {
+            num_rows: Some(2),
+            num_levels: Some(6),
+            num_nulls: Some(0),
+            is_dict: false,
+        };
+        validate_vector_page_metadata(0, 0, &valid, 3).unwrap();
+
+        let invalid = PageMetadata {
+            num_rows: Some(2),
+            num_levels: Some(5),
+            num_nulls: Some(0),
+            is_dict: false,
+        };
+        let err = validate_vector_page_metadata(0, 0, &invalid, 3)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("num_values 5") && err.contains("vector_length 3"),
+            "unexpected error: {err}"
+        );
+
+        let sparse = PageMetadata {
+            num_rows: Some(2),
+            num_levels: Some(6),
+            num_nulls: Some(1),
+            is_dict: false,
+        };
+        let err = validate_vector_page_metadata(0, 0, &sparse, 3)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("null values"), "unexpected error: {err}");
+    }
+
+    fn vector_data_page_v2(num_nulls: u32) -> Page {
+        Page::DataPageV2 {
+            buf: Bytes::new(),
+            num_values: 6,
+            encoding: Encoding::PLAIN,
+            num_nulls,
+            num_rows: 2,
+            def_levels_byte_len: 0,
+            rep_levels_byte_len: 0,
+            is_compressed: false,
+            statistics: None,
+        }
+    }
+
+    #[test]
+    fn vector_data_page_v2_must_be_dense() {
+        let err = validate_vector_page(0, 0, &vector_data_page_v2(1), 3)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("null values"), "unexpected error: {err}");
+    }
+
+    struct MockPageReader {
+        metadata: Option<PageMetadata>,
+        page: Option<Page>,
+        get_called: Arc<AtomicBool>,
+        skip_called: Arc<AtomicBool>,
+    }
+
+    impl Iterator for MockPageReader {
+        type Item = Result<Page>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.get_next_page().transpose()
+        }
+    }
+
+    impl PageReader for MockPageReader {
+        fn get_next_page(&mut self) -> Result<Option<Page>> {
+            self.get_called.store(true, Ordering::SeqCst);
+            Ok(self.page.take())
+        }
+
+        fn peek_next_page(&mut self) -> Result<Option<PageMetadata>> {
+            Ok(self.metadata.clone())
+        }
+
+        fn skip_next_page(&mut self) -> Result<()> {
+            self.skip_called.store(true, Ordering::SeqCst);
+            self.metadata = None;
+            self.page = None;
+            Ok(())
+        }
+    }
+
+    fn skip_vector_page(metadata: PageMetadata, page: Option<Page>) -> (String, bool, bool) {
+        let get_called = Arc::new(AtomicBool::new(false));
+        let skip_called = Arc::new(AtomicBool::new(false));
+        let inner = MockPageReader {
+            metadata: Some(metadata),
+            page,
+            get_called: Arc::clone(&get_called),
+            skip_called: Arc::clone(&skip_called),
+        };
+        let mut reader = VectorPageReader {
+            inner: Box::new(inner),
+            col_idx: 0,
+            vector_length: 3,
+            row_group_idx: 0,
+        };
+
+        let err = reader.skip_next_page().unwrap_err().to_string();
+        (
+            err,
+            get_called.load(Ordering::SeqCst),
+            skip_called.load(Ordering::SeqCst),
+        )
+    }
+
+    #[test]
+    fn vector_skip_next_page_validates_dense_pages() {
+        let (err, get_called, skip_called) = skip_vector_page(
+            PageMetadata {
+                num_rows: Some(2),
+                num_levels: Some(6),
+                num_nulls: Some(1),
+                is_dict: false,
+            },
+            None,
+        );
+        assert!(err.contains("null values"), "unexpected error: {err}");
+        assert!(!get_called);
+        assert!(!skip_called);
+
+        let (err, get_called, skip_called) = skip_vector_page(
+            PageMetadata {
+                num_rows: Some(2),
+                num_levels: None,
+                num_nulls: None,
+                is_dict: false,
+            },
+            Some(vector_data_page_v2(1)),
+        );
+        assert!(err.contains("null values"), "unexpected error: {err}");
+        assert!(get_called);
+        assert!(!skip_called);
     }
 
     #[test]

--- a/parquet/src/arrow/array_reader/fixed_size_list_vector_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_size_list_vector_array.rs
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::{Array, ArrayRef, FixedSizeListArray, new_empty_array};
+use arrow_schema::{DataType as ArrowType, FieldRef};
+
+use crate::arrow::array_reader::ArrayReader;
+use crate::errors::{ParquetError, Result};
+
+/// Reader for the canonical Parquet `VECTOR` encoding.
+///
+/// A `VECTOR` column stores a fixed number `N` of element values per row under a
+/// VECTOR-repeated middle group that contributes no definition or repetition
+/// levels (`num_values == num_rows * N`). This reader wraps the leaf's primitive
+/// [`ArrayReader`] and reshapes its flat output into a [`FixedSizeListArray`]:
+/// requesting `R` rows reads `R * N` flat element values from the inner reader,
+/// and the resulting length-`R * N` array is grouped into `R` rows of size `N`.
+///
+/// The wrapped column is non-nullable (vector and elements), so this reader
+/// produces no definition or repetition levels.
+pub struct FixedSizeListVectorArrayReader {
+    /// Reader for the flattened element values
+    item_reader: Box<dyn ArrayReader>,
+    /// Number of element values per row (`vector_length`)
+    fixed_size: usize,
+    /// The `FixedSizeList` data type produced by this reader
+    data_type: ArrowType,
+    /// Child element field, extracted from `data_type`
+    field: FieldRef,
+}
+
+impl FixedSizeListVectorArrayReader {
+    /// Construct a `VECTOR` reshape reader.
+    ///
+    /// `data_type` must be a [`ArrowType::FixedSizeList`] whose size equals
+    /// `fixed_size`.
+    pub fn new(
+        item_reader: Box<dyn ArrayReader>,
+        fixed_size: usize,
+        data_type: ArrowType,
+    ) -> Result<Self> {
+        if fixed_size == 0 {
+            return Err(general_err!("VECTOR vector_length must be positive"));
+        }
+        let field = match &data_type {
+            ArrowType::FixedSizeList(field, size) if *size as usize == fixed_size => field.clone(),
+            other => {
+                return Err(general_err!(
+                    "FixedSizeListVectorArrayReader requires a FixedSizeList of size {}, got {}",
+                    fixed_size,
+                    other
+                ));
+            }
+        };
+        Ok(Self {
+            item_reader,
+            fixed_size,
+            data_type,
+            field,
+        })
+    }
+
+    /// `rows * fixed_size`, erroring on overflow rather than wrapping.
+    fn values_for(&self, rows: usize) -> Result<usize> {
+        rows.checked_mul(self.fixed_size).ok_or_else(|| {
+            general_err!(
+                "VECTOR row count {rows} * vector_length {} overflows usize",
+                self.fixed_size
+            )
+        })
+    }
+}
+
+impl ArrayReader for FixedSizeListVectorArrayReader {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn get_data_type(&self) -> &ArrowType {
+        &self.data_type
+    }
+
+    fn read_records(&mut self, batch_size: usize) -> Result<usize> {
+        // Each row maps to `fixed_size` contiguous leaf values. Because the leaf
+        // has no repetition levels, the inner reader treats one value as one
+        // record, and whole-vector page boundaries guarantee the returned count
+        // is a multiple of `fixed_size`.
+        let values_read = self
+            .item_reader
+            .read_records(self.values_for(batch_size)?)?;
+        if values_read % self.fixed_size != 0 {
+            return Err(general_err!(
+                "VECTOR column read {values_read} values which is not a multiple of vector_length {}",
+                self.fixed_size
+            ));
+        }
+        Ok(values_read / self.fixed_size)
+    }
+
+    fn consume_batch(&mut self) -> Result<ArrayRef> {
+        let values = self.item_reader.consume_batch()?;
+        if values.is_empty() {
+            return Ok(new_empty_array(&self.data_type));
+        }
+        if values.len() % self.fixed_size != 0 {
+            return Err(general_err!(
+                "VECTOR column produced {} values which is not a multiple of vector_length {}",
+                values.len(),
+                self.fixed_size
+            ));
+        }
+        let array =
+            FixedSizeListArray::try_new(self.field.clone(), self.fixed_size as i32, values, None)?;
+        Ok(Arc::new(array))
+    }
+
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        // Use decoder-level skip for whole vectors. Decoding and discarding would
+        // flush the inner buffer and drop rows already read by interleaved
+        // RowSelection paths.
+        let skipped_values = self
+            .item_reader
+            .skip_records(self.values_for(num_records)?)?;
+        // A clean skip lands on a whole-vector boundary.
+        if skipped_values % self.fixed_size != 0 {
+            return Err(general_err!(
+                "VECTOR column skipped {skipped_values} values which is not a multiple of vector_length {}",
+                self.fixed_size
+            ));
+        }
+        Ok(skipped_values / self.fixed_size)
+    }
+
+    fn get_def_levels(&self) -> Option<&[i16]> {
+        // VECTOR columns are non-nullable and carry no definition levels.
+        None
+    }
+
+    fn get_rep_levels(&self) -> Option<&[i16]> {
+        // VECTOR columns carry no repetition levels by construction.
+        None
+    }
+}

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -38,6 +38,7 @@ mod cached_array_reader;
 mod empty_array;
 mod fixed_len_byte_array;
 mod fixed_size_list_array;
+mod fixed_size_list_vector_array;
 mod list_array;
 mod list_view_array;
 mod map_array;
@@ -61,6 +62,7 @@ pub use byte_view_array::make_byte_view_array_reader;
 #[allow(unused_imports)] // Only used for benchmarks
 pub use fixed_len_byte_array::make_fixed_len_byte_array_reader;
 pub use fixed_size_list_array::FixedSizeListArrayReader;
+pub use fixed_size_list_vector_array::FixedSizeListVectorArrayReader;
 pub use list_array::ListArrayReader;
 pub use list_view_array::ListViewArrayReader;
 pub use map_array::MapArrayReader;

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -40,6 +40,7 @@
 //!
 //! \[1\] [parquet-format#nested-encoding](https://github.com/apache/parquet-format#nested-encoding)
 
+use crate::arrow::schema::vector_eligible_fixed_size_list;
 use crate::column::chunker::CdcChunk;
 use crate::column::writer::LevelDataRef;
 use crate::errors::{ParquetError, Result};
@@ -75,8 +76,86 @@ fn expand_typed_ree<R: RunEndIndexType>(run_array: &RunArray<R>) -> Result<Array
 }
 
 /// Performs a depth-first scan of the children of `array`, constructing [`ArrayLevels`]
-/// for each leaf column encountered
+/// for each leaf column encountered.
+///
+/// When `vector_encoding` is set and `field` is a top-level VECTOR-eligible
+/// `FixedSizeList`, the list is flattened into a single level-free element leaf
+/// of `rows * size` values, matching the canonical `VECTOR` schema produced by
+/// the schema converter. Nested `FixedSizeList`s are never flattened.
+#[cfg(test)]
 pub(crate) fn calculate_array_levels(array: &ArrayRef, field: &Field) -> Result<Vec<ArrayLevels>> {
+    calculate_array_levels_with_options(array, field, false)
+}
+
+/// Like `calculate_array_levels`, with `vector_encoding` selecting whether an
+/// eligible top-level `FixedSizeList` is flattened into a Parquet `VECTOR` column.
+pub(crate) fn calculate_array_levels_with_options(
+    array: &ArrayRef,
+    field: &Field,
+    vector_encoding: bool,
+) -> Result<Vec<ArrayLevels>> {
+    if vector_encoding {
+        if let Some((element, size)) = vector_eligible_fixed_size_list(field) {
+            match array.data_type() {
+                DataType::FixedSizeList(array_element, array_size)
+                    if *array_size == size
+                        && element
+                            .data_type()
+                            .equals_datatype(array_element.data_type()) => {}
+                _ => {
+                    return Err(arrow_err!(
+                        "Incompatible type. Field '{}' has type {}, array has type {}",
+                        field.name(),
+                        field.data_type(),
+                        array.data_type()
+                    ));
+                }
+            }
+
+            let list = array.as_fixed_size_list();
+            if list.null_count() != 0 {
+                return Err(arrow_err!(
+                    "VECTOR column '{}' contains {} null vector values; VECTOR requires dense non-null FixedSizeList values",
+                    field.name(),
+                    list.null_count()
+                ));
+            }
+
+            let size = size as usize;
+            let offset = list.offset().checked_mul(size).ok_or_else(|| {
+                arrow_err!(
+                    "VECTOR column '{}' offset {} * vector_length {} overflows usize",
+                    field.name(),
+                    list.offset(),
+                    size
+                )
+            })?;
+            let len = list.len().checked_mul(size).ok_or_else(|| {
+                arrow_err!(
+                    "VECTOR column '{}' length {} * vector_length {} overflows usize",
+                    field.name(),
+                    list.len(),
+                    size
+                )
+            })?;
+
+            // Slice the child to this array's logical range, then emit the flat
+            // element values with no definition or repetition levels.
+            let values = list.values().slice(offset, len);
+            if values.null_count() != 0 {
+                return Err(arrow_err!(
+                    "VECTOR column '{}' contains {} null element values; VECTOR requires dense non-null elements",
+                    field.name(),
+                    values.null_count()
+                ));
+            }
+
+            let mut builder =
+                LevelInfoBuilder::try_new(element.as_ref(), Default::default(), &values)?;
+            builder.write(0..values.len());
+            return Ok(builder.finish());
+        }
+    }
     let mut builder = LevelInfoBuilder::try_new(field, Default::default(), array)?;
     builder.write(0..array.len());
     Ok(builder.finish())
@@ -2540,6 +2619,94 @@ mod tests {
         assert_eq!(
             err,
             "Arrow: Incompatible type. Field 'item' has type Float64, array has type Int32",
+        );
+    }
+
+    #[test]
+    fn vector_encoding_mismatched_array_type_errors() {
+        let field = Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Float32, false)), 2),
+            false,
+        );
+        let array = Arc::new(Int32Array::from_iter(0..4)) as ArrayRef;
+
+        let err = calculate_array_levels_with_options(&array, &field, true)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Incompatible type") && err.contains("array has type Int32"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_encoding_mismatched_list_size_errors() {
+        let field = Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Float32, false)), 2),
+            false,
+        );
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let values = Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])) as ArrayRef;
+        let array = Arc::new(FixedSizeListArray::new(element, 3, values, None)) as ArrayRef;
+
+        let err = calculate_array_levels_with_options(&array, &field, true)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Incompatible type") && err.contains("FixedSizeList"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_encoding_rejects_null_vector_values() {
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let values = Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0])) as ArrayRef;
+        let array = Arc::new(FixedSizeListArray::new(
+            element,
+            2,
+            values,
+            Some(NullBuffer::from(vec![true, false])),
+        )) as ArrayRef;
+        let field = Field::new("embedding", array.data_type().clone(), false);
+
+        let err = calculate_array_levels_with_options(&array, &field, true)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("null vector values"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_encoding_rejects_null_element_values() {
+        // Build an array whose child permits nulls, but pass the writer a
+        // non-nullable VECTOR-eligible field. This mirrors the writer's runtime
+        // guard: field nullability alone must not cause null element values to be
+        // flattened as valid VECTOR data.
+        let array_element = Arc::new(Field::new("element", DataType::Float32, true));
+        let values = Arc::new(Float32Array::from(vec![
+            Some(1.0),
+            None,
+            Some(3.0),
+            Some(4.0),
+        ])) as ArrayRef;
+        let array = Arc::new(FixedSizeListArray::new(array_element, 2, values, None)) as ArrayRef;
+        let field = Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Float32, false)), 2),
+            false,
+        );
+
+        let err = calculate_array_levels_with_options(&array, &field, true)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("null element values"),
+            "unexpected error: {err}"
         );
     }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -36,7 +36,8 @@ use super::schema::{add_encoded_arrow_schema_to_metadata, decimal_length_from_pr
 
 use crate::arrow::ArrowSchemaConverter;
 use crate::arrow::arrow_writer::byte_array::ByteArrayEncoder;
-use crate::basic::PageType;
+use crate::arrow::schema::vector_eligible_fixed_size_list;
+use crate::basic::{LogicalType, PageType};
 use crate::column::page::{CompressedPage, PageWriteSpec, PageWriter};
 use crate::column::page_encryption::PageEncryptor;
 use crate::column::writer::encoder::ColumnValueEncoder;
@@ -51,8 +52,8 @@ use crate::file::metadata::{KeyValue, ParquetMetaData, RowGroupMetaData};
 use crate::file::properties::{WriterProperties, WriterPropertiesPtr};
 use crate::file::writer::{SerializedFileWriter, SerializedRowGroupWriter};
 use crate::parquet_thrift::{ThriftCompactOutputProtocol, WriteThrift};
-use crate::schema::types::{ColumnDescPtr, SchemaDescPtr, SchemaDescriptor};
-use levels::{ArrayLevels, calculate_array_levels};
+use crate::schema::types::{ColumnDescPtr, SchemaDescPtr, SchemaDescriptor, Type};
+use levels::{ArrayLevels, calculate_array_levels_with_options};
 
 mod byte_array;
 mod levels;
@@ -248,7 +249,9 @@ impl<W: Write + Send> ArrowWriter<W> {
         let schema = if let Some(parquet_schema) = options.schema_descr {
             parquet_schema.clone()
         } else {
-            let mut converter = ArrowSchemaConverter::new().with_coerce_types(props.coerce_types());
+            let mut converter = ArrowSchemaConverter::new()
+                .with_coerce_types(props.coerce_types())
+                .with_vector_encoding(props.vector_encoding());
             if let Some(schema_root) = &options.schema_root {
                 converter = converter.schema_root(schema_root);
             }
@@ -943,8 +946,33 @@ pub struct ArrowLeafColumn(ArrayLevels);
 ///
 /// This function can be used along with [`get_column_writers`] to encode
 /// individual columns in parallel. See example on [`ArrowColumnWriter`]
+///
+/// Note: for a Parquet schema built with EXPERIMENTAL VECTOR encoding
+/// ([`ArrowSchemaConverter::with_vector_encoding`]), use
+/// [`compute_leaves_with_options`] with a matching `vector_encoding` flag instead,
+/// so the produced leaves line up with the VECTOR column writers.
 pub fn compute_leaves(field: &Field, array: &ArrayRef) -> Result<Vec<ArrowLeafColumn>> {
-    let levels = calculate_array_levels(array, field)?;
+    compute_leaves_with_options(field, array, false)
+}
+
+/// Like [`compute_leaves`], but with `vector_encoding` selecting whether an
+/// eligible top-level `FixedSizeList` is flattened into a Parquet `VECTOR` column
+/// (EXPERIMENTAL).
+///
+/// When using the lower-level parallel column-writer API ([`get_column_writers`]
+/// / [`ArrowRowGroupWriterFactory`]) with a schema built using
+/// [`ArrowSchemaConverter::with_vector_encoding`] /
+/// [`WriterPropertiesBuilder::set_vector_encoding`], pass the **same**
+/// `vector_encoding` value here so the produced leaves line up with the column
+/// writers; otherwise the leaf shapes will not match the Parquet schema.
+///
+/// [`WriterPropertiesBuilder::set_vector_encoding`]: crate::file::properties::WriterPropertiesBuilder::set_vector_encoding
+pub fn compute_leaves_with_options(
+    field: &Field,
+    array: &ArrayRef,
+    vector_encoding: bool,
+) -> Result<Vec<ArrowLeafColumn>> {
+    let levels = calculate_array_levels_with_options(array, field, vector_encoding)?;
     Ok(levels.into_iter().map(ArrowLeafColumn).collect())
 }
 
@@ -1212,6 +1240,40 @@ impl ArrowColumnWriter {
     }
 }
 
+fn vector_length_for_root_field(field: &Type) -> Option<i32> {
+    if field.get_basic_info().logical_type_ref() == Some(&LogicalType::Vector) {
+        field
+            .get_fields()
+            .first()
+            .and_then(|list| list.vector_length())
+    } else {
+        None
+    }
+}
+
+/// Returns whether the top-level field at `idx` is VECTOR-encoded, validating that
+/// the Arrow `FixedSizeList` matches the Parquet `vector_length`. A mismatch would
+/// silently corrupt row counts (the column writer divides values by the Parquet
+/// length while the row group counts Arrow rows), so it is rejected.
+fn vector_field_flatten(vector_lengths: &[Option<i32>], idx: usize, field: &Field) -> Result<bool> {
+    match vector_lengths.get(idx).copied().flatten() {
+        Some(expected) => match vector_eligible_fixed_size_list(field) {
+            Some((_, size)) if size == expected => Ok(true),
+            Some((_, size)) => Err(general_err!(
+                "VECTOR column '{}' has Parquet vector_length {} but Arrow FixedSizeList size {}",
+                field.name(),
+                expected,
+                size
+            )),
+            None => Err(general_err!(
+                "VECTOR column '{}' must be backed by a non-nullable FixedSizeList with a fixed-width primitive element",
+                field.name()
+            )),
+        },
+        None => Ok(false),
+    }
+}
+
 /// Encodes [`RecordBatch`] to a parquet row group
 ///
 /// Note: this structure is created by [`ArrowRowGroupWriterFactory`] internally used to
@@ -1223,22 +1285,34 @@ struct ArrowRowGroupWriter {
     writers: Vec<ArrowColumnWriter>,
     schema: SchemaRef,
     buffered_rows: usize,
+    /// Per top-level Arrow field: the Parquet `VECTOR` length, if that field is
+    /// encoded as a VECTOR column. Derived from the actual Parquet schema (not the
+    /// `vector_encoding` flag), so it stays correct even when an explicit schema
+    /// is supplied.
+    vector_lengths: Vec<Option<i32>>,
 }
 
 impl ArrowRowGroupWriter {
-    fn new(writers: Vec<ArrowColumnWriter>, arrow: &SchemaRef) -> Self {
+    fn new(
+        writers: Vec<ArrowColumnWriter>,
+        arrow: &SchemaRef,
+        vector_lengths: Vec<Option<i32>>,
+    ) -> Self {
         Self {
             writers,
             schema: arrow.clone(),
             buffered_rows: 0,
+            vector_lengths,
         }
     }
 
     fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         self.buffered_rows += batch.num_rows();
+        let vector_lengths = &self.vector_lengths;
         let mut writers = self.writers.iter_mut();
-        for (field, column) in self.schema.fields().iter().zip(batch.columns()) {
-            for leaf in compute_leaves(field.as_ref(), column)? {
+        for (idx, (field, column)) in self.schema.fields().iter().zip(batch.columns()).enumerate() {
+            let vector = vector_field_flatten(vector_lengths, idx, field)?;
+            for leaf in compute_leaves_with_options(field.as_ref(), column, vector)? {
                 writers.next().unwrap().write(&leaf)?;
             }
         }
@@ -1251,14 +1325,24 @@ impl ArrowRowGroupWriter {
         chunkers: &mut [ContentDefinedChunker],
     ) -> Result<()> {
         self.buffered_rows += batch.num_rows();
+        let vector_lengths = &self.vector_lengths;
         let mut writers = self.writers.iter_mut();
         let mut chunkers = chunkers.iter_mut();
-        for (field, column) in self.schema.fields().iter().zip(batch.columns()) {
-            for leaf in compute_leaves(field.as_ref(), column)? {
-                writers
-                    .next()
-                    .unwrap()
-                    .write_with_chunker(&leaf, chunkers.next().unwrap())?;
+        for (idx, (field, column)) in self.schema.fields().iter().zip(batch.columns()).enumerate() {
+            // EXPERIMENTAL: content-defined chunking slices the flattened element
+            // stream at arbitrary offsets, which would split a vector value across
+            // pages (a VECTOR column has no levels to delimit records). Route
+            // VECTOR-encoded columns through the regular, vector-aligned write path
+            // instead; their (single) chunker is consumed but unused.
+            let is_vector = vector_field_flatten(vector_lengths, idx, field)?;
+            for leaf in compute_leaves_with_options(field.as_ref(), column, is_vector)? {
+                let writer = writers.next().unwrap();
+                let chunker = chunkers.next().unwrap();
+                if is_vector {
+                    writer.write(&leaf)?;
+                } else {
+                    writer.write_with_chunker(&leaf, chunker)?;
+                }
             }
         }
         Ok(())
@@ -1325,7 +1409,27 @@ impl ArrowRowGroupWriterFactory {
 
     fn create_row_group_writer(&self, row_group_index: usize) -> Result<ArrowRowGroupWriter> {
         let writers = self.create_column_writers(row_group_index)?;
-        Ok(ArrowRowGroupWriter::new(writers, &self.arrow_schema))
+        // Derive the per-field VECTOR length from the actual Parquet schema: a
+        // top-level field is flattened iff its Parquet root field is a VECTOR
+        // logical group whose middle `list` group carries vector_length. This
+        // stays correct even when an explicit (possibly non-VECTOR) schema is
+        // supplied alongside `vector_encoding`.
+        let vector_lengths = self
+            .schema
+            .root_schema()
+            .get_fields()
+            .iter()
+            .map(|f| vector_length_for_root_field(f.as_ref()))
+            .collect::<Vec<_>>();
+        // `vector_lengths` is indexed positionally by top-level Arrow field; this
+        // relies on the 1:1 correspondence between Arrow fields and Parquet root
+        // fields that the column-writer mapping also assumes.
+        debug_assert_eq!(vector_lengths.len(), self.arrow_schema.fields().len());
+        Ok(ArrowRowGroupWriter::new(
+            writers,
+            &self.arrow_schema,
+            vector_lengths,
+        ))
     }
 
     /// Create column writers for a new row group, with the given row group index
@@ -5471,6 +5575,1049 @@ mod tests {
             total_values as usize, num_rows,
             "expected every level position to be represented in some page"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // EXPERIMENTAL: canonical VECTOR logical/repetition type tests
+    // ------------------------------------------------------------------
+
+    /// Does the schema converter encode `field` as a Parquet VECTOR column when
+    /// vector encoding is enabled?
+    fn converts_to_vector(field: Field) -> bool {
+        let schema = Schema::new(vec![field]);
+        let descr = ArrowSchemaConverter::new()
+            .with_vector_encoding(true)
+            .convert(&schema)
+            .unwrap();
+        (0..descr.num_columns()).any(|i| descr.column(i).vector_length().is_some())
+    }
+
+    fn float_fsl(element_nullable: bool, size: i32) -> DataType {
+        DataType::FixedSizeList(
+            Arc::new(Field::new("element", DataType::Float32, element_nullable)),
+            size,
+        )
+    }
+
+    #[test]
+    fn vector_encoding_eligibility() {
+        // Eligible: non-nullable FixedSizeList<Float32, 3> with non-nullable element.
+        assert!(converts_to_vector(Field::new(
+            "e",
+            float_fsl(false, 3),
+            false
+        )));
+
+        // Fixed-width decimal elements (all widths) are eligible.
+        for dt in [
+            DataType::Decimal32(9, 2),
+            DataType::Decimal64(18, 2),
+            DataType::Decimal128(38, 2),
+            DataType::Decimal256(76, 2),
+        ] {
+            let fsl = DataType::FixedSizeList(Arc::new(Field::new("element", dt, false)), 4);
+            assert!(converts_to_vector(Field::new("e", fsl, false)));
+        }
+
+        // Nullable outer list → fallback to LIST.
+        assert!(!converts_to_vector(Field::new(
+            "e",
+            float_fsl(false, 3),
+            true
+        )));
+        // Nullable element → fallback.
+        assert!(!converts_to_vector(Field::new(
+            "e",
+            float_fsl(true, 3),
+            false
+        )));
+        // Zero-length → fallback.
+        assert!(!converts_to_vector(Field::new(
+            "e",
+            float_fsl(false, 0),
+            false
+        )));
+        // Variable-width (Utf8) element → fallback.
+        let utf8_fsl =
+            DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Utf8, false)), 3);
+        assert!(!converts_to_vector(Field::new("e", utf8_fsl, false)));
+        // Nested FixedSizeList (top-level is List) → inner FSL uses LIST.
+        let nested = DataType::List(Arc::new(Field::new("item", float_fsl(false, 3), false)));
+        assert!(!converts_to_vector(Field::new("e", nested, false)));
+    }
+
+    #[test]
+    #[cfg(feature = "arrow_canonical_extension_types")]
+    fn vector_encoding_uuid_self_describing_roundtrip() {
+        use arrow_schema::extension::Uuid;
+
+        let n = 2i32;
+        let rows = 3usize;
+        let raw: Vec<[u8; 16]> = (0..(rows * n as usize)).map(|i| [i as u8; 16]).collect();
+        let values =
+            Arc::new(FixedSizeBinaryArray::try_from_iter(raw.into_iter()).unwrap()) as ArrayRef;
+        let element = Arc::new(
+            Field::new("element", DataType::FixedSizeBinary(16), false).with_extension_type(Uuid),
+        );
+        let list = FixedSizeListArray::new(element, n, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ids",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        // skip_arrow_metadata=true forces self-describing reconstruction (no hint).
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        // Reading back must not error, and the UUID extension lands on the child.
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        assert_eq!(
+            builder
+                .metadata()
+                .file_metadata()
+                .schema_descr()
+                .column(0)
+                .vector_length(),
+            Some(2)
+        );
+        let out_field = builder.schema().field(0).clone();
+        match out_field.data_type() {
+            DataType::FixedSizeList(child, 2) => {
+                assert!(!out_field.metadata().contains_key("ARROW:extension:name"));
+                assert_eq!(
+                    child
+                        .metadata()
+                        .get("ARROW:extension:name")
+                        .map(String::as_str),
+                    Some("arrow.uuid")
+                );
+            }
+            other => panic!("expected FixedSizeList(_, 2), got {other:?}"),
+        }
+        let mut reader = builder.build().unwrap();
+        assert_eq!(reader.next().unwrap().unwrap().num_rows(), 3);
+    }
+
+    #[test]
+    #[cfg(feature = "arrow_canonical_extension_types")]
+    fn vector_encoding_preserves_element_extension_metadata() {
+        use crate::basic::{LogicalType, Repetition};
+        use arrow_schema::extension::Uuid;
+
+        // A UUID extension on the FixedSizeBinary(16) element must survive into the
+        // VECTOR element leaf's logical type, matching the standard LIST encoding.
+        let element = Arc::new(
+            Field::new("element", DataType::FixedSizeBinary(16), false).with_extension_type(Uuid),
+        );
+        let schema = Schema::new(vec![Field::new(
+            "ids",
+            DataType::FixedSizeList(element, 2),
+            false,
+        )]);
+        let descr = ArrowSchemaConverter::new()
+            .with_vector_encoding(true)
+            .convert(&schema)
+            .unwrap();
+        let col = descr.column(0);
+        let root = descr.root_schema().get_fields()[0].as_ref();
+        assert_eq!(
+            root.get_basic_info().logical_type_ref(),
+            Some(&LogicalType::Vector)
+        );
+        let list = root.get_fields()[0].as_ref();
+        assert_eq!(list.get_basic_info().repetition(), Repetition::VECTOR);
+        assert_eq!(list.vector_length(), Some(2));
+        assert_eq!(col.vector_length(), Some(2));
+        assert_eq!(
+            col.self_type().get_basic_info().logical_type_ref(),
+            Some(&LogicalType::Uuid)
+        );
+    }
+
+    #[test]
+    fn vector_encoding_explicit_schema_length_mismatch_errors() {
+        use crate::basic::{LogicalType, Repetition, Type as PhysicalType};
+
+        // Arrow FixedSizeList<Float32, 3>.
+        let values = Arc::new(Float32Array::from(
+            (0..12).map(|v| v as f32).collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, 3, values, None);
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        // Explicit Parquet schema declaring a *different* VECTOR length (2 vs 3).
+        let leaf = Arc::new(
+            Type::primitive_type_builder("element", PhysicalType::FLOAT)
+                .with_repetition(Repetition::REQUIRED)
+                .build()
+                .unwrap(),
+        );
+        let list = Arc::new(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::VECTOR)
+                .with_vector_length(Some(2))
+                .with_fields(vec![leaf])
+                .build()
+                .unwrap(),
+        );
+        let vector = Arc::new(
+            Type::group_type_builder("embedding")
+                .with_repetition(Repetition::REQUIRED)
+                .with_logical_type(Some(LogicalType::Vector))
+                .with_fields(vec![list])
+                .build()
+                .unwrap(),
+        );
+        let root = Arc::new(
+            Type::group_type_builder("arrow_schema")
+                .with_fields(vec![vector])
+                .build()
+                .unwrap(),
+        );
+        let parquet_schema = SchemaDescriptor::new(root);
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_parquet_schema(parquet_schema)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), arrow_schema, options).unwrap();
+        let err = writer.write(&batch).unwrap_err();
+        assert!(
+            err.to_string().contains("vector_length 2") && err.to_string().contains("size 3"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_encoding_ignored_with_explicit_list_schema() {
+        // An explicit (non-VECTOR) Parquet schema must win over a stray
+        // `vector_encoding=true`: the writer must NOT flatten the FixedSizeList,
+        // otherwise it would feed a level-free leaf to a LIST column writer.
+        let flat: Vec<f32> = (0..12).map(|v| v as f32).collect();
+        let values = Arc::new(Float32Array::from(flat.clone())) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, 3, values, None);
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        // Build a standard LIST Parquet schema (no vector encoding).
+        let parquet_schema = ArrowSchemaConverter::new().convert(&arrow_schema).unwrap();
+        assert!(parquet_schema.column(0).vector_length().is_none());
+
+        // Supply the explicit LIST schema but (incorrectly) also enable vector
+        // encoding via properties.
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_parquet_schema(parquet_schema)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), arrow_schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        // No VECTOR column: the explicit LIST schema was honored.
+        assert!(
+            builder
+                .metadata()
+                .file_metadata()
+                .schema_descr()
+                .column(0)
+                .vector_length()
+                .is_none()
+        );
+        // And the data reads back intact (as a 3-level list).
+        let reader = builder.build().unwrap();
+        let mut total = 0usize;
+        for b in reader {
+            total += b.unwrap().num_rows();
+        }
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn vector_encoding_disabled_by_default() {
+        let schema = Schema::new(vec![Field::new("e", float_fsl(false, 3), false)]);
+        let descr = ArrowSchemaConverter::new().convert(&schema).unwrap();
+        assert!(!(0..descr.num_columns()).any(|i| descr.column(i).vector_length().is_some()));
+    }
+
+    #[test]
+    fn vector_encoding_roundtrip_self_describing() {
+        use crate::basic::{LogicalType, Repetition};
+
+        let flat: Vec<f32> = (0..12).map(|v| v as f32).collect();
+        let values = Arc::new(Float32Array::from(flat.clone())) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, 3, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        // skip_arrow_metadata=true proves the FixedSizeList is recovered from the
+        // Parquet schema alone, without the embedded ARROW:schema hint.
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), schema.clone(), options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+
+        // The Parquet schema carries the VECTOR repetition and vector_length.
+        let descr = builder.metadata().file_metadata().schema_descr();
+        assert_eq!(descr.num_columns(), 1);
+        let col = descr.column(0);
+        let root = descr.root_schema().get_fields()[0].as_ref();
+        assert_eq!(
+            root.get_basic_info().logical_type_ref(),
+            Some(&LogicalType::Vector)
+        );
+        let list = root.get_fields()[0].as_ref();
+        assert_eq!(list.get_basic_info().repetition(), Repetition::VECTOR);
+        assert_eq!(list.vector_length(), Some(3));
+        assert_eq!(col.vector_length(), Some(3));
+
+        // num_values == rows * N, num_rows == rows.
+        let rg = builder.metadata().row_group(0);
+        assert_eq!(rg.num_rows(), 4);
+        assert_eq!(rg.column(0).num_values(), 12);
+
+        // The Arrow schema is recovered as a non-nullable FixedSizeList.
+        let out_field = builder.schema().field(0).clone();
+        assert!(!out_field.is_nullable());
+        assert_eq!(
+            out_field.data_type(),
+            &DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Float32, false)), 3)
+        );
+
+        let mut reader = builder.build().unwrap();
+        let out = reader.next().unwrap().unwrap();
+        assert_eq!(out.num_rows(), 4);
+        let out_list = out.column(0).as_fixed_size_list();
+        assert_eq!(out_list.value_length(), 3);
+        assert_eq!(out_list.null_count(), 0);
+        let recovered = out_list.values().as_primitive::<Float32Type>();
+        assert_eq!(recovered.values(), &flat[..]);
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn vector_encoding_roundtrip_with_arrow_schema_hint() {
+        // Same as the self-describing test but keeping the embedded ARROW:schema
+        // hint (the default). The reconstruction must still produce a
+        // FixedSizeList and round-trip the data, across multiple batches/row
+        // groups.
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let make_batch = |start: i32, rows: usize| {
+            let flat: Vec<f32> = (0..(rows as i32 * 3)).map(|v| (start + v) as f32).collect();
+            let values = Arc::new(Float32Array::from(flat)) as ArrayRef;
+            let list = FixedSizeListArray::new(element.clone(), 3, values, None);
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "embedding",
+                list.data_type().clone(),
+                false,
+            )]));
+            RecordBatch::try_new(schema, vec![Arc::new(list)]).unwrap()
+        };
+
+        let b0 = make_batch(0, 4);
+        let b1 = make_batch(100, 2);
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .set_max_row_group_row_count(Some(4))
+            .build();
+        let options = ArrowWriterOptions::new().with_properties(props);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), b0.schema(), options).unwrap();
+        writer.write(&b0).unwrap();
+        writer.write(&b1).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        // Even with the hint present, the leaf is VECTOR-encoded.
+        assert_eq!(
+            builder
+                .metadata()
+                .file_metadata()
+                .schema_descr()
+                .num_columns(),
+            1
+        );
+        assert_eq!(
+            builder
+                .metadata()
+                .file_metadata()
+                .schema_descr()
+                .column(0)
+                .vector_length(),
+            Some(3)
+        );
+        let out_field = builder.schema().field(0).clone();
+        assert!(matches!(
+            out_field.data_type(),
+            DataType::FixedSizeList(_, 3)
+        ));
+
+        let reader = builder.build().unwrap();
+        let mut all = Vec::new();
+        let mut rows = 0;
+        for b in reader {
+            let b = b.unwrap();
+            rows += b.num_rows();
+            let list = b.column(0).as_fixed_size_list();
+            let flat = list.values().as_primitive::<Float32Type>();
+            all.extend_from_slice(flat.values());
+        }
+        assert_eq!(rows, 6);
+        let mut expected: Vec<f32> = (0..12).map(|v| v as f32).collect();
+        expected.extend((0..6).map(|v| (100 + v) as f32));
+        assert_eq!(all, expected);
+    }
+
+    #[test]
+    fn vector_encoding_roundtrip_sliced_array() {
+        // A sliced FixedSizeListArray has a non-zero offset; the write path must
+        // slice the child by `offset * size` to emit the correct logical range.
+        let n = 3i32;
+        let total_rows = 6usize;
+        let values = Arc::new(Float32Array::from(
+            (0..(total_rows as i32 * n))
+                .map(|v| v as f32)
+                .collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let full = FixedSizeListArray::new(
+            Arc::new(Field::new("element", DataType::Float32, false)),
+            n,
+            values,
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            full.data_type().clone(),
+            false,
+        )]));
+        let full_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(full)]).unwrap();
+        // Rows 2..5 (offset 2, len 3).
+        let batch = full_batch.slice(2, 3);
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        assert_eq!(builder.metadata().row_group(0).num_rows(), 3);
+        assert_eq!(builder.metadata().row_group(0).column(0).num_values(), 9);
+        let mut reader = builder.build().unwrap();
+        let out = reader.next().unwrap().unwrap();
+        assert_eq!(out.num_rows(), 3);
+        let list = out.column(0).as_fixed_size_list();
+        // rows 2,3,4 → element values 6..15
+        assert_eq!(
+            list.values().as_primitive::<Float32Type>().values(),
+            &(6..15).map(|v| v as f32).collect::<Vec<_>>()[..]
+        );
+    }
+
+    #[test]
+    fn vector_encoding_read_under_row_filter() {
+        use crate::arrow::ProjectionMask;
+        use crate::arrow::arrow_reader::{ArrowPredicateFn, RowFilter};
+
+        // Predicate pushdown drives the row-group cache and the VECTOR reader's
+        // skip/read accounting (the CachedArrayReader wraps the reshape wrapper).
+        let n = 3i32;
+        let num_rows = 200usize;
+        let ids = Arc::new(Int32Array::from((0..num_rows as i32).collect::<Vec<_>>())) as ArrayRef;
+        let emb_values = Arc::new(Float32Array::from(
+            (0..(num_rows as i32 * n))
+                .map(|v| v as f32)
+                .collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let emb = FixedSizeListArray::new(
+            Arc::new(Field::new("element", DataType::Float32, false)),
+            n,
+            emb_values,
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("embedding", emb.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids, Arc::new(emb)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .set_dictionary_enabled(false)
+            .set_data_page_size_limit(256)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        let schema_desc = builder.metadata().file_metadata().schema_descr_ptr();
+        // Predicate on `id` (leaf 0): id >= 100.
+        let projection = ProjectionMask::leaves(&schema_desc, [0]);
+        let predicate = ArrowPredicateFn::new(projection, |batch: RecordBatch| {
+            let ids = batch.column(0);
+            arrow::compute::kernels::cmp::gt_eq(ids, &Int32Array::new_scalar(100))
+        });
+        let filter = RowFilter::new(vec![Box::new(predicate)]);
+        let reader = builder.with_row_filter(filter).build().unwrap();
+
+        let mut ids_out = Vec::new();
+        let mut emb_out = Vec::new();
+        for b in reader {
+            let b = b.unwrap();
+            ids_out.extend_from_slice(b.column(0).as_primitive::<Int32Type>().values());
+            let emb = b.column(1).as_fixed_size_list();
+            assert_eq!(emb.value_length(), 3);
+            emb_out.extend_from_slice(emb.values().as_primitive::<Float32Type>().values());
+        }
+        // Rows 100..200 survive the filter.
+        assert_eq!(ids_out, (100..200).collect::<Vec<i32>>());
+        let expected_emb: Vec<f32> = ((100 * n as usize)..(num_rows * n as usize))
+            .map(|v| v as f32)
+            .collect();
+        assert_eq!(emb_out, expected_emb);
+    }
+
+    #[test]
+    fn vector_encoding_mixed_with_scalar_column() {
+        // A VECTOR column and a scalar column in one row group must agree on the
+        // logical row count (VECTOR rows = values/N, scalar rows = values). The
+        // writer cross-checks this, so a wrong row count would fail the write.
+        let n = 3i32;
+        let num_rows = 100usize;
+        let emb_values = Arc::new(Float32Array::from(
+            (0..(num_rows as i32 * n))
+                .map(|v| v as f32)
+                .collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let emb = FixedSizeListArray::new(
+            Arc::new(Field::new("element", DataType::Float32, false)),
+            n,
+            emb_values,
+            None,
+        );
+        let ids = Arc::new(Int32Array::from((0..num_rows as i32).collect::<Vec<_>>())) as ArrayRef;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("embedding", emb.data_type().clone(), false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(emb), ids]).unwrap();
+
+        // Small pages so each column spans several pages.
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .set_dictionary_enabled(false)
+            .set_data_page_size_limit(256)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        let md = builder.metadata().clone();
+        assert_eq!(md.row_group(0).num_rows(), num_rows as i64);
+        let descr = md.file_metadata().schema_descr();
+        assert_eq!(descr.column(0).vector_length(), Some(3));
+        assert!(descr.column(1).vector_length().is_none());
+        // VECTOR column chunk holds num_rows*n values; scalar column holds num_rows.
+        assert_eq!(md.row_group(0).column(0).num_values(), num_rows as i64 * 3);
+        assert_eq!(md.row_group(0).column(1).num_values(), num_rows as i64);
+
+        let reader = builder.build().unwrap();
+        let mut rows = 0usize;
+        let mut ids_out = Vec::new();
+        for b in reader {
+            let b = b.unwrap();
+            rows += b.num_rows();
+            assert_eq!(b.column(0).as_fixed_size_list().value_length(), 3);
+            ids_out.extend_from_slice(b.column(1).as_primitive::<Int32Type>().values());
+        }
+        assert_eq!(rows, num_rows);
+        assert_eq!(ids_out, (0..num_rows as i32).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn vector_encoding_roundtrip_decimal_and_fixed_size_binary() {
+        // Exercise element types whose Parquet physical mapping differs from FLOAT:
+        // Decimal128(38,5) → FLBA(16), and a plain FixedSizeBinary(4) → FLBA(4).
+        let dec_in: Vec<i128> = (0..6).collect();
+        let dec_values = Decimal128Array::from(dec_in.clone())
+            .with_precision_and_scale(38, 5)
+            .unwrap();
+        let dec_list = FixedSizeListArray::new(
+            Arc::new(Field::new("element", DataType::Decimal128(38, 5), false)),
+            2,
+            Arc::new(dec_values) as ArrayRef,
+            None,
+        );
+
+        let raw: Vec<[u8; 4]> = (0..6).map(|i| [i as u8; 4]).collect();
+        let bin_values = FixedSizeBinaryArray::try_from_iter(raw.into_iter()).unwrap();
+        let bin_list = FixedSizeListArray::new(
+            Arc::new(Field::new("element", DataType::FixedSizeBinary(4), false)),
+            2,
+            Arc::new(bin_values) as ArrayRef,
+            None,
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("dec", dec_list.data_type().clone(), false),
+            Field::new("bin", bin_list.data_type().clone(), false),
+        ]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(dec_list), Arc::new(bin_list)])
+                .unwrap();
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        let descr = builder.metadata().file_metadata().schema_descr();
+        assert_eq!(descr.column(0).vector_length(), Some(2));
+        assert_eq!(descr.column(1).vector_length(), Some(2));
+
+        let mut reader = builder.build().unwrap();
+        let out = reader.next().unwrap().unwrap();
+        assert_eq!(out.num_rows(), 3);
+
+        let dec_out = out.column(0).as_fixed_size_list();
+        assert_eq!(dec_out.value_length(), 2);
+        assert_eq!(
+            dec_out.values().as_primitive::<Decimal128Type>().values(),
+            &dec_in[..]
+        );
+        assert_eq!(dec_out.values().data_type(), &DataType::Decimal128(38, 5));
+
+        let bin_out = out.column(1).as_fixed_size_list();
+        assert_eq!(bin_out.value_length(), 2);
+        let bin_inner = bin_out
+            .values()
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        assert_eq!(bin_inner.value(0), [0u8; 4]);
+        assert_eq!(bin_inner.value(5), [5u8; 4]);
+    }
+
+    #[test]
+    fn vector_encoding_pages_aligned_to_whole_vectors() {
+        let n: i32 = 5;
+        let num_rows = 1000usize;
+        let total = num_rows * n as usize;
+        let flat: Vec<f32> = (0..total).map(|v| v as f32).collect();
+        let values = Arc::new(Float32Array::from(flat)) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, n, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        // Small page size + a write batch size that is not a multiple of N, to
+        // force many pages and exercise the vector-boundary alignment.
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .set_dictionary_enabled(false)
+            .set_data_page_size_limit(256)
+            .set_write_batch_size(13)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), schema.clone(), options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let mut metadata = ParquetMetaDataReader::new();
+        metadata.try_parse(&data).unwrap();
+        let metadata = metadata.finish().unwrap();
+        let rg = metadata.row_group(0);
+        assert_eq!(rg.num_rows() as usize, num_rows);
+        let col_meta = rg.column(0);
+        assert_eq!(col_meta.num_values() as usize, total);
+
+        // Every data page must end on a whole-vector boundary.
+        let mut reader =
+            SerializedPageReader::new(Arc::new(data.clone()), col_meta, num_rows, None).unwrap();
+        let mut data_pages = 0;
+        while let Some(page) = reader.get_next_page().unwrap() {
+            if matches!(page, Page::DataPage { .. } | Page::DataPageV2 { .. }) {
+                assert_eq!(
+                    page.num_values() as usize % n as usize,
+                    0,
+                    "a data page split a vector value"
+                );
+                data_pages += 1;
+            }
+        }
+        assert!(
+            data_pages > 1,
+            "expected multiple data pages, got {data_pages}"
+        );
+
+        // And the data round-trips correctly.
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        let reader = builder.build().unwrap();
+        let mut seen = 0usize;
+        for b in reader {
+            seen += b.unwrap().num_rows();
+        }
+        assert_eq!(seen, num_rows);
+    }
+
+    #[test]
+    fn vector_encoding_interleaved_row_selection() {
+        use crate::arrow::arrow_reader::{RowSelection, RowSelectionPolicy, RowSelector};
+
+        // A selection that interleaves select/skip/select within one output batch
+        // exercises the `Selectors` path, where read_records and skip_records run
+        // before a single terminal consume_batch. A skip that flushed the inner
+        // buffer would drop the previously-selected rows.
+        let n = 3i32;
+        let num_rows = 100usize;
+        let emb_values = Arc::new(Float32Array::from(
+            (0..(num_rows as i32 * n))
+                .map(|v| v as f32)
+                .collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let emb = FixedSizeListArray::new(
+            Arc::new(Field::new("element", DataType::Float32, false)),
+            n,
+            emb_values,
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            emb.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(emb)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        // Select rows 0..30 and 50..80.
+        let selection = RowSelection::from(vec![
+            RowSelector::select(30),
+            RowSelector::skip(20),
+            RowSelector::select(30),
+            RowSelector::skip(20),
+        ]);
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data)
+            .unwrap()
+            .with_row_selection_policy(RowSelectionPolicy::Selectors)
+            .with_row_selection(selection);
+        let reader = builder.build().unwrap();
+        let mut got = Vec::new();
+        for b in reader {
+            let b = b.unwrap();
+            got.extend_from_slice(
+                b.column(0)
+                    .as_fixed_size_list()
+                    .values()
+                    .as_primitive::<Float32Type>()
+                    .values(),
+            );
+        }
+        let mut expected: Vec<f32> = (0..(30 * n as usize)).map(|v| v as f32).collect();
+        expected.extend(((50 * n as usize)..(80 * n as usize)).map(|v| v as f32));
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn vector_encoding_v2_page_skip_with_row_selection() {
+        use crate::arrow::arrow_reader::{RowSelection, RowSelector};
+        use crate::file::properties::WriterVersion;
+
+        let n: i32 = 4;
+        let num_rows = 500usize;
+        let total = num_rows * n as usize;
+        let flat: Vec<f32> = (0..total).map(|v| v as f32).collect();
+        let values = Arc::new(Float32Array::from(flat)) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, n, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        // DataPageV2 + small pages so a row selection skips across page
+        // boundaries, exercising the VECTOR skip path (whose V2 page num_rows is
+        // logical-rows, not flat values).
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .set_writer_version(WriterVersion::PARQUET_2_0)
+            .set_dictionary_enabled(false)
+            .set_data_page_size_limit(512)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), schema.clone(), options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        // Skip the first 250 rows, select the next 250.
+        let selection = RowSelection::from(vec![RowSelector::skip(250), RowSelector::select(250)]);
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data)
+            .unwrap()
+            .with_row_selection(selection);
+        let reader = builder.build().unwrap();
+        let mut got = Vec::new();
+        let mut rows = 0usize;
+        for b in reader {
+            let b = b.unwrap();
+            rows += b.num_rows();
+            let list = b.column(0).as_fixed_size_list();
+            let fv = list.values().as_primitive::<Float32Type>();
+            got.extend_from_slice(fv.values());
+        }
+        assert_eq!(rows, 250);
+        // Rows 250..500 → element values 1000..2000.
+        let expected: Vec<f32> = ((250 * n as usize)..total).map(|v| v as f32).collect();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn vector_encoding_rejected_by_record_row_api() {
+        use crate::file::reader::{FileReader, SerializedFileReader};
+
+        let values = Arc::new(Float32Array::from(
+            (0..6).map(|v| v as f32).collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, 3, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer = ArrowWriter::try_new_with_options(Vec::new(), schema, options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        // The legacy row-based record API must reject VECTOR columns rather than
+        // silently reading one element per row.
+        let reader = SerializedFileReader::new(data).unwrap();
+        let result = reader
+            .get_row_iter(None)
+            .and_then(|mut it| match it.next() {
+                Some(row) => row.map(|_| ()),
+                None => Ok(()),
+            });
+        let err = result.expect_err("record row API should reject VECTOR columns");
+        assert!(
+            err.to_string().contains("VECTOR"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_encoding_pages_aligned_with_dictionary() {
+        // Like vector_encoding_pages_aligned_to_whole_vectors but with dictionary
+        // encoding ENABLED, covering the dict-fallback page path.
+        let n: i32 = 5;
+        let num_rows = 1000usize;
+        let total = num_rows * n as usize;
+        // Low cardinality so dictionary encoding is used.
+        let flat: Vec<f32> = (0..total).map(|v| (v % 7) as f32).collect();
+        let values = Arc::new(Float32Array::from(flat)) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, n, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            // dictionary encoding left enabled (the default)
+            .set_data_page_size_limit(256)
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), schema.clone(), options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let mut metadata = ParquetMetaDataReader::new();
+        metadata.try_parse(&data).unwrap();
+        let metadata = metadata.finish().unwrap();
+        let col_meta = metadata.row_group(0).column(0);
+        let mut reader =
+            SerializedPageReader::new(Arc::new(data.clone()), col_meta, num_rows, None).unwrap();
+        let mut data_pages = 0;
+        while let Some(page) = reader.get_next_page().unwrap() {
+            if matches!(page, Page::DataPage { .. } | Page::DataPageV2 { .. }) {
+                assert_eq!(
+                    page.num_values() as usize % n as usize,
+                    0,
+                    "dictionary path split a vector value across a data page"
+                );
+                data_pages += 1;
+            }
+        }
+        assert!(
+            data_pages > 1,
+            "expected multiple data pages, got {data_pages}"
+        );
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        let reader = builder.build().unwrap();
+        let mut rows = 0usize;
+        for b in reader {
+            rows += b.unwrap().num_rows();
+        }
+        assert_eq!(rows, num_rows);
+    }
+
+    #[test]
+    fn vector_encoding_with_content_defined_chunking_keeps_vectors_whole() {
+        use crate::file::properties::CdcOptions;
+
+        // Content-defined chunking must not split a vector across pages: VECTOR
+        // columns are routed through the regular vector-aligned write path.
+        let n: i32 = 5;
+        let num_rows = 2000usize;
+        let total = num_rows * n as usize;
+        let flat: Vec<f32> = (0..total).map(|v| v as f32).collect();
+        let values = Arc::new(Float32Array::from(flat)) as ArrayRef;
+        let element = Arc::new(Field::new("element", DataType::Float32, false));
+        let list = FixedSizeListArray::new(element, n, values, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_vector_encoding(true)
+            .set_dictionary_enabled(false)
+            .set_content_defined_chunking(Some(CdcOptions {
+                min_chunk_size: 64,
+                max_chunk_size: 512,
+                norm_level: 0,
+            }))
+            .build();
+        let options = ArrowWriterOptions::new()
+            .with_properties(props)
+            .with_skip_arrow_metadata(true);
+        let mut writer =
+            ArrowWriter::try_new_with_options(Vec::new(), schema.clone(), options).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let mut metadata = ParquetMetaDataReader::new();
+        metadata.try_parse(&data).unwrap();
+        let metadata = metadata.finish().unwrap();
+        let rg = metadata.row_group(0);
+        assert_eq!(rg.num_rows() as usize, num_rows);
+        let col_meta = rg.column(0);
+        assert_eq!(col_meta.num_values() as usize, total);
+
+        let mut reader =
+            SerializedPageReader::new(Arc::new(data.clone()), col_meta, num_rows, None).unwrap();
+        while let Some(page) = reader.get_next_page().unwrap() {
+            if matches!(page, Page::DataPage { .. } | Page::DataPageV2 { .. }) {
+                assert_eq!(
+                    page.num_values() as usize % n as usize,
+                    0,
+                    "CDC split a vector value across a data page"
+                );
+            }
+        }
+
+        // Data round-trips correctly.
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data).unwrap();
+        let reader = builder.build().unwrap();
+        let mut seen = 0usize;
+        for b in reader {
+            seen += b.unwrap().num_rows();
+        }
+        assert_eq!(seen, num_rows);
     }
 
     struct WriteBatchesShape {

--- a/parquet/src/arrow/schema/complex.rs
+++ b/parquet/src/arrow/schema/complex.rs
@@ -22,7 +22,7 @@ use crate::arrow::schema::extension::try_add_extension_type;
 use crate::arrow::schema::primitive::convert_primitive;
 use crate::arrow::schema::virtual_type::{RowGroupIndex, RowNumber};
 use crate::arrow::{PARQUET_FIELD_ID_META_KEY, ProjectionMask};
-use crate::basic::{ConvertedType, Repetition};
+use crate::basic::{ConvertedType, LogicalType, Repetition};
 use crate::errors::ParquetError;
 use crate::errors::Result;
 use crate::schema::types::{SchemaDescriptor, Type, TypePtr};
@@ -149,6 +149,9 @@ pub enum ParquetFieldType {
         col_idx: usize,
         /// The type of the column in parquet
         primitive_type: TypePtr,
+        /// Fixed vector length if this primitive is the leaf under a canonical
+        /// VECTOR-repeated group.
+        vector_length: Option<i32>,
     },
     Group {
         children: Vec<ParquetField>,
@@ -175,6 +178,14 @@ struct VisitorContext {
     ///
     /// [1]: https://github.com/apache/parquet-format/blob/38818fa0e7efd54b535001a4448030a40619c2a3/LogicalTypes.md?plain=1#L718-L806
     treat_repeated_as_list_arrow_hint: bool,
+
+    /// Fixed vector length if the current subtree is under a canonical
+    /// VECTOR-repeated middle group.
+    vector_length: Option<i32>,
+
+    /// Depth of the current Parquet type from the schema root. The root message
+    /// itself is depth 0; top-level fields are depth 1.
+    depth: usize,
 }
 
 impl VisitorContext {
@@ -185,6 +196,10 @@ impl VisitorContext {
             Repetition::OPTIONAL => (self.def_level + 1, self.rep_level, true),
             Repetition::REQUIRED => (self.def_level, self.rep_level, false),
             Repetition::REPEATED => (self.def_level + 1, self.rep_level + 1, false),
+            // A VECTOR-repeated middle group does not raise the definition or
+            // repetition level of its descendants. Its fixed multiplicity is
+            // carried by SchemaElement::vector_length.
+            Repetition::VECTOR => (self.def_level, self.rep_level, false),
         }
     }
 }
@@ -216,6 +231,12 @@ impl Visitor {
         }
 
         let repetition = get_repetition(primitive_type);
+        if repetition == Repetition::VECTOR {
+            return Err(arrow_err!(
+                "VECTOR repetition is only valid on group fields, not primitive field '{}'",
+                primitive_type.name()
+            ));
+        }
         let (def_level, rep_level, nullable) = context.levels(repetition);
 
         let primitive_arrow_data_type = match repetition {
@@ -240,6 +261,13 @@ impl Visitor {
 
         let arrow_type = convert_primitive(primitive_type, primitive_arrow_data_type)?;
 
+        if context.vector_length.is_some() && arrow_type == DataType::Null {
+            return Err(arrow_err!(
+                "VECTOR element '{}' has an unsupported null/unknown element type",
+                primitive_type.name()
+            ));
+        }
+
         let primitive_field = ParquetField {
             rep_level,
             def_level,
@@ -248,6 +276,7 @@ impl Visitor {
             field_type: ParquetFieldType::Primitive {
                 primitive_type: primitive_type.clone(),
                 col_idx,
+                vector_length: context.vector_length,
             },
         };
 
@@ -345,6 +374,8 @@ impl Visitor {
                 // not its children. A repeated child's arrow hint will be List<...>
                 // and needs to be unwrapped accordingly.
                 treat_repeated_as_list_arrow_hint: true,
+                vector_length: None,
+                depth: context.depth + 1,
             };
 
             if let Some(child) = self.dispatch(parquet_field, child_ctx)? {
@@ -376,6 +407,108 @@ impl Visitor {
         }))
     }
 
+    fn visit_vector(
+        &mut self,
+        vector_type: &TypePtr,
+        context: VisitorContext,
+    ) -> Result<Option<ParquetField>> {
+        if vector_type.is_primitive() {
+            return Err(arrow_err!(
+                "{:?} is a VECTOR type and must be a group.",
+                vector_type
+            ));
+        }
+
+        let repetition = get_repetition(vector_type);
+        let (def_level, rep_level, nullable) = match repetition {
+            Repetition::REQUIRED | Repetition::OPTIONAL => context.levels(repetition),
+            Repetition::REPEATED => return Err(arrow_err!("VECTOR type cannot be repeated")),
+            Repetition::VECTOR => {
+                return Err(arrow_err!(
+                    "VECTOR logical type cannot use VECTOR repetition"
+                ));
+            }
+        };
+
+        let fields = vector_type.get_fields();
+        if fields.len() != 1 || fields[0].name() != "list" {
+            return Err(arrow_err!(
+                "VECTOR logical type must have a single child named 'list', found {} child(ren)",
+                fields.len()
+            ));
+        }
+
+        let list = &fields[0];
+        if !list.is_group() || get_repetition(list) != Repetition::VECTOR {
+            return Err(arrow_err!(
+                "VECTOR logical type child 'list' must be a VECTOR-repeated group"
+            ));
+        }
+        let vector_length = list
+            .vector_length()
+            .ok_or_else(|| arrow_err!("VECTOR-repeated group 'list' is missing vector_length"))?;
+
+        let items = list.get_fields();
+        if items.len() != 1 || items[0].name() != "element" {
+            return Err(arrow_err!(
+                "VECTOR-repeated group 'list' must have a single child named 'element', found {} child(ren)",
+                items.len()
+            ));
+        }
+        let element_type = &items[0];
+        if !element_type.is_primitive() {
+            return Err(arrow_err!(
+                "reading VECTOR columns with non-primitive elements is not supported"
+            ));
+        }
+        if get_repetition(element_type) != Repetition::REQUIRED {
+            return Err(arrow_err!(
+                "VECTOR element '{}' must be required, not {}",
+                element_type.name(),
+                get_repetition(element_type)
+            ));
+        }
+
+        let arrow_child_hint = match &context.data_type {
+            Some(DataType::FixedSizeList(child, _)) => Some(child.as_ref()),
+            Some(d) => {
+                return Err(arrow_err!(
+                    "incompatible arrow schema, expected fixed-size list got {}",
+                    d
+                ));
+            }
+            None => None,
+        };
+
+        let child_context = VisitorContext {
+            rep_level,
+            def_level,
+            data_type: arrow_child_hint.map(|f| f.data_type().clone()),
+            treat_repeated_as_list_arrow_hint: true,
+            vector_length: Some(vector_length),
+            depth: context.depth + 2,
+        };
+
+        match self.dispatch(element_type, child_context) {
+            Ok(Some(item)) => {
+                let mut item_field = convert_field(element_type, &item, arrow_child_hint, true)?;
+                if let Some(hint) = arrow_child_hint {
+                    item_field = item_field.with_name(hint.name());
+                }
+                Ok(Some(ParquetField {
+                    rep_level,
+                    def_level,
+                    nullable,
+                    arrow_type: DataType::FixedSizeList(Arc::new(item_field), vector_length),
+                    field_type: ParquetFieldType::Group {
+                        children: vec![item],
+                    },
+                }))
+            }
+            r => r,
+        }
+    }
+
     fn visit_map(
         &mut self,
         map_type: &TypePtr,
@@ -386,6 +519,7 @@ impl Visitor {
             Repetition::REQUIRED => (context.def_level + 1, false),
             Repetition::OPTIONAL => (context.def_level + 2, true),
             Repetition::REPEATED => return Err(arrow_err!("Map cannot be repeated")),
+            Repetition::VECTOR => return Err(arrow_err!("Map cannot use VECTOR repetition")),
         };
 
         if map_type.get_fields().len() != 1 {
@@ -421,6 +555,9 @@ impl Visitor {
         match map_key.get_basic_info().repetition() {
             Repetition::REPEATED => {
                 return Err(arrow_err!("Map keys cannot be repeated"));
+            }
+            Repetition::VECTOR => {
+                return Err(arrow_err!("Map keys cannot use VECTOR repetition"));
             }
             Repetition::REQUIRED | Repetition::OPTIONAL => {
                 // Relaxed check for having repetition REQUIRED as there exists
@@ -467,6 +604,8 @@ impl Visitor {
                 data_type: arrow_key.map(|x| x.data_type().clone()),
                 // Key is not repeated
                 treat_repeated_as_list_arrow_hint: false,
+                vector_length: None,
+                depth: context.depth + 2,
             };
 
             self.dispatch(map_key, context)?
@@ -479,6 +618,8 @@ impl Visitor {
                 data_type: arrow_value.map(|x| x.data_type().clone()),
                 // Value type can be repeated
                 treat_repeated_as_list_arrow_hint: true,
+                vector_length: None,
+                depth: context.depth + 2,
             };
 
             self.dispatch(map_value, context)?
@@ -549,6 +690,7 @@ impl Visitor {
             Repetition::REQUIRED => (context.def_level, false),
             Repetition::OPTIONAL => (context.def_level + 1, true),
             Repetition::REPEATED => return Err(arrow_err!("List type cannot be repeated")),
+            Repetition::VECTOR => return Err(arrow_err!("List type cannot use VECTOR repetition")),
         };
 
         let arrow_field = match &context.data_type {
@@ -578,6 +720,8 @@ impl Visitor {
                 def_level,
                 data_type: arrow_field.map(|f| f.data_type().clone()),
                 treat_repeated_as_list_arrow_hint: false,
+                vector_length: None,
+                depth: context.depth + 1,
             };
 
             return match self.visit_primitive(repeated_field, context) {
@@ -610,6 +754,8 @@ impl Visitor {
                 def_level,
                 data_type: arrow_field.map(|f| f.data_type().clone()),
                 treat_repeated_as_list_arrow_hint: false,
+                vector_length: None,
+                depth: context.depth + 1,
             };
 
             return match self.visit_struct(repeated_field, context) {
@@ -631,6 +777,8 @@ impl Visitor {
             rep_level,
             data_type: arrow_field.map(|f| f.data_type().clone()),
             treat_repeated_as_list_arrow_hint: true,
+            vector_length: None,
+            depth: context.depth + 2,
         };
 
         match self.dispatch(item_type, new_context) {
@@ -669,6 +817,21 @@ impl Visitor {
     ) -> Result<Option<ParquetField>> {
         if cur_type.is_primitive() {
             self.visit_primitive(cur_type, context)
+        } else if cur_type.get_basic_info().logical_type_ref() == Some(&LogicalType::Vector) {
+            if context.depth != 1 {
+                return Err(arrow_err!(
+                    "VECTOR logical type group '{}' is only supported as a top-level field",
+                    cur_type.name()
+                ));
+            }
+            self.visit_vector(cur_type, context)
+        } else if cur_type.get_basic_info().has_repetition()
+            && cur_type.get_basic_info().repetition() == Repetition::VECTOR
+        {
+            Err(arrow_err!(
+                "VECTOR repetition group '{}' must be the 'list' child of a VECTOR logical type",
+                cur_type.name()
+            ))
         } else {
             match cur_type.get_basic_info().converted_type() {
                 ConvertedType::LIST => self.visit_list(cur_type, context),
@@ -771,9 +934,14 @@ fn convert_field(
                 );
                 ret.set_metadata(meta);
             }
-            try_add_extension_type(ret, parquet_type)
+            add_extension_type(ret, parquet_type)
         }
     }
+}
+
+/// Applies a Parquet logical-type extension (UUID, JSON, etc.) to `field`.
+pub(crate) fn add_extension_type(field: Field, parquet_type: &Type) -> Result<Field, ParquetError> {
+    try_add_extension_type(field, parquet_type)
 }
 
 /// Computes the [`ParquetField`] for the provided [`SchemaDescriptor`] with `leaf_columns` listing
@@ -796,6 +964,8 @@ pub fn convert_schema(
         def_level: 0,
         data_type: embedded_arrow_schema.map(|fields| DataType::Struct(fields.clone())),
         treat_repeated_as_list_arrow_hint: true,
+        vector_length: None,
+        depth: 0,
     };
 
     visitor.dispatch(&schema.root_schema_ptr(), context)
@@ -814,6 +984,8 @@ pub fn convert_type(parquet_type: &TypePtr) -> Result<ParquetField> {
         data_type: None,
         // We might be inside list
         treat_repeated_as_list_arrow_hint: false,
+        vector_length: None,
+        depth: 1,
     };
 
     Ok(visitor.dispatch(parquet_type, context)?.unwrap())
@@ -1877,5 +2049,132 @@ message schema {
                 true,
             )]),
         )
+    }
+
+    #[test]
+    fn canonical_vector_schema_converts_to_fixed_size_list() -> crate::errors::Result<()> {
+        test_expected_type(
+            "
+            message schema {
+              required group v (VECTOR) {
+                vector group list [3] {
+                  required float element;
+                }
+              }
+            }
+            ",
+            Fields::from(vec![Field::new(
+                "v",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("element", DataType::Float32, false)),
+                    3,
+                ),
+                false,
+            )]),
+        )
+    }
+
+    #[test]
+    fn standalone_vector_repetition_group_is_rejected() {
+        use crate::basic::{Repetition, Type as PhysicalType};
+        use crate::schema::types::Type;
+
+        let element = Arc::new(
+            Type::primitive_type_builder("element", PhysicalType::FLOAT)
+                .with_repetition(Repetition::REQUIRED)
+                .build()
+                .unwrap(),
+        );
+        let list = Arc::new(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::VECTOR)
+                .with_vector_length(Some(3))
+                .with_fields(vec![element])
+                .build()
+                .unwrap(),
+        );
+        let root = Arc::new(
+            Type::group_type_builder("schema")
+                .with_fields(vec![list])
+                .build()
+                .unwrap(),
+        );
+        let descr = SchemaDescriptor::new(root);
+
+        let err = convert_schema(&descr, ProjectionMask::all(), None).unwrap_err();
+        assert!(
+            err.to_string().contains("VECTOR logical type"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn nested_vector_logical_group_is_rejected() {
+        let schema = Arc::new(
+            parse_message_type(
+                "
+                message schema {
+                  required group s {
+                    required group v (VECTOR) {
+                      vector group list [3] {
+                        required float element;
+                      }
+                    }
+                  }
+                }
+                ",
+            )
+            .unwrap(),
+        );
+        let descr = SchemaDescriptor::new(schema);
+
+        let err = convert_schema(&descr, ProjectionMask::all(), None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("top-level field"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn vector_leaf_with_null_element_is_rejected() {
+        use crate::basic::{LogicalType, Repetition, Type as PhysicalType};
+        use crate::schema::types::Type;
+
+        // An Unknown/Null element type is contradictory for a dense vector.
+        let element = Arc::new(
+            Type::primitive_type_builder("element", PhysicalType::INT32)
+                .with_repetition(Repetition::REQUIRED)
+                .with_logical_type(Some(LogicalType::Unknown))
+                .build()
+                .unwrap(),
+        );
+        let list = Arc::new(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::VECTOR)
+                .with_vector_length(Some(3))
+                .with_fields(vec![element])
+                .build()
+                .unwrap(),
+        );
+        let vector = Arc::new(
+            Type::group_type_builder("v")
+                .with_repetition(Repetition::REQUIRED)
+                .with_logical_type(Some(LogicalType::Vector))
+                .with_fields(vec![list])
+                .build()
+                .unwrap(),
+        );
+        let root = Arc::new(
+            Type::group_type_builder("schema")
+                .with_fields(vec![vector])
+                .build()
+                .unwrap(),
+        );
+        let descr = SchemaDescriptor::new(root);
+
+        let err = convert_schema(&descr, ProjectionMask::all(), None).unwrap_err();
+        assert!(
+            err.to_string().contains("null/unknown element"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -42,7 +42,6 @@ use crate::arrow::ProjectionMask;
 use crate::arrow::schema::extension::{
     has_extension_type, logical_type_for_binary, logical_type_for_binary_view,
     logical_type_for_fixed_size_binary, logical_type_for_string, logical_type_for_struct,
-    try_add_extension_type,
 };
 pub(crate) use complex::{ParquetField, ParquetFieldType, VirtualColumnType};
 
@@ -422,6 +421,11 @@ pub struct ArrowSchemaConverter<'a> {
     ///
     /// See docs on [Self::with_coerce_types]`
     coerce_types: bool,
+    /// Should eligible top-level `FixedSizeList` columns be encoded using the
+    /// Parquet `VECTOR` logical/repetition types?
+    ///
+    /// See docs on [Self::with_vector_encoding]
+    vector_encoding: bool,
 }
 
 impl Default for ArrowSchemaConverter<'_> {
@@ -436,6 +440,7 @@ impl<'a> ArrowSchemaConverter<'a> {
         Self {
             schema_root: "arrow_schema",
             coerce_types: false,
+            vector_encoding: false,
         }
     }
 
@@ -474,6 +479,22 @@ impl<'a> ArrowSchemaConverter<'a> {
         self
     }
 
+    /// EXPERIMENTAL: encode eligible top-level Arrow `FixedSizeList` columns using
+    /// the Parquet `VECTOR` logical type / repetition type instead of the standard
+    /// 3-level `LIST` encoding (default `false`).
+    ///
+    /// Only a non-nullable `FixedSizeList` with a positive size and a non-nullable
+    /// fixed-width primitive element qualifies; all other `FixedSizeList` columns
+    /// fall back to the `LIST` encoding. See
+    /// [`WriterPropertiesBuilder::set_vector_encoding`] for the on-disk format and
+    /// compatibility caveats.
+    ///
+    /// [`WriterPropertiesBuilder::set_vector_encoding`]: crate::file::properties::WriterPropertiesBuilder::set_vector_encoding
+    pub fn with_vector_encoding(mut self, vector_encoding: bool) -> Self {
+        self.vector_encoding = vector_encoding;
+        self
+    }
+
     /// Set the root schema element name (defaults to `"arrow_schema"`).
     pub fn schema_root(mut self, schema_root: &'a str) -> Self {
         self.schema_root = schema_root;
@@ -487,13 +508,160 @@ impl<'a> ArrowSchemaConverter<'a> {
         let fields = schema
             .fields()
             .iter()
-            .map(|field| arrow_to_parquet_type(field, self.coerce_types).map(Arc::new))
+            .map(|field| {
+                // EXPERIMENTAL: the VECTOR decision is made here, at the top level
+                // only, so we only ever produce dense (no nullable/repeated
+                // ancestor) vectors. Nested `FixedSizeList`s go through the normal
+                // `LIST` path inside `arrow_to_parquet_type`.
+                if self.vector_encoding {
+                    if let Some((element, len)) = vector_eligible_fixed_size_list(field) {
+                        return fixed_size_list_to_vector_type(
+                            field,
+                            element,
+                            len,
+                            self.coerce_types,
+                        )
+                        .map(Arc::new);
+                    }
+                }
+                arrow_to_parquet_type(field, self.coerce_types).map(Arc::new)
+            })
             .collect::<Result<_>>()?;
         let group = Type::group_type_builder(self.schema_root)
             .with_fields(fields)
             .build()?;
         Ok(SchemaDescriptor::new(Arc::new(group)))
     }
+}
+
+/// Returns `Some((element_field, len))` when `field` is a top-level Arrow
+/// `FixedSizeList` eligible for the Parquet `VECTOR` encoding: a non-nullable
+/// list with a positive size whose element is a non-nullable, fixed-width
+/// primitive. Returns `None` otherwise (caller falls back to `LIST`).
+///
+/// Shared by the schema converter and the write-side level builder so both make
+/// the identical encoding decision.
+pub(crate) fn vector_eligible_fixed_size_list(field: &Field) -> Option<(&FieldRef, i32)> {
+    if field.is_nullable() {
+        return None;
+    }
+    match field.data_type() {
+        DataType::FixedSizeList(element, len)
+            if *len > 0
+                && !element.is_nullable()
+                && is_supported_vector_element_type(element.data_type()) =>
+        {
+            Some((element, *len))
+        }
+        _ => None,
+    }
+}
+
+/// Whether an Arrow `FixedSizeList` element type can be encoded as a Parquet
+/// `VECTOR` element in this implementation: only fixed-width primitive elements
+/// qualify. Variable-width (Utf8/Binary), view, nested, and null types
+/// are excluded and use the standard `LIST` encoding instead.
+///
+/// Note: this is a structural check. If an otherwise-eligible element type has no
+/// Parquet primitive mapping (so [`arrow_to_parquet_type`] errors — e.g. a future
+/// `Interval` subtype), the VECTOR write surfaces that as an error rather than
+/// silently falling back to `LIST`; the standard `LIST` encoding of the same
+/// element would fail identically, so this is not a behavioral difference.
+fn is_supported_vector_element_type(dt: &DataType) -> bool {
+    use DataType::*;
+    matches!(
+        dt,
+        Boolean
+            | Int8
+            | Int16
+            | Int32
+            | Int64
+            | UInt8
+            | UInt16
+            | UInt32
+            | UInt64
+            | Float16
+            | Float32
+            | Float64
+            | Decimal32(_, _)
+            | Decimal64(_, _)
+            | Decimal128(_, _)
+            | Decimal256(_, _)
+            | Date32
+            | Date64
+            | Time32(_)
+            | Time64(_)
+            | Timestamp(_, _)
+            | Duration(_)
+            | Interval(_)
+            | FixedSizeBinary(_)
+    )
+}
+
+/// Builds the canonical 3-level Parquet `VECTOR` encoding for an eligible Arrow
+/// `FixedSizeList` field:
+///
+/// ```text
+/// required group <field> (VECTOR) {
+///   vector group list [N] {
+///     required <element-type> element;
+///   }
+/// }
+/// ```
+///
+/// The element's physical/logical type is derived using the normal primitive
+/// mapping. The VECTOR-repeated middle group carries `vector_length` and adds no
+/// definition or repetition level.
+fn fixed_size_list_to_vector_type(
+    field: &Field,
+    element: &FieldRef,
+    len: i32,
+    coerce_types: bool,
+) -> Result<Type> {
+    let name = field.name().as_str();
+    // Map the element to a Parquet primitive named `element`. Preserve the
+    // element metadata so metadata-driven mappings (e.g. the UUID extension on
+    // FixedSizeBinary(16)) match the standard LIST encoding.
+    let element_field = Field::new("element", element.data_type().clone(), false)
+        .with_metadata(element.metadata().clone());
+    let element_type = arrow_to_parquet_type(&element_field, coerce_types)?;
+    let Type::PrimitiveType {
+        basic_info,
+        physical_type,
+        type_length,
+        scale,
+        precision,
+        ..
+    } = element_type
+    else {
+        return Err(arrow_err!(
+            "VECTOR element of field '{}' did not map to a Parquet primitive type",
+            name
+        ));
+    };
+
+    let element_leaf = Type::primitive_type_builder("element", physical_type)
+        .with_repetition(Repetition::REQUIRED)
+        .with_length(type_length)
+        .with_precision(precision)
+        .with_scale(scale)
+        .with_logical_type(basic_info.logical_type_ref().cloned())
+        .with_converted_type(basic_info.converted_type())
+        .with_id(field_id(element.as_ref()))
+        .build()?;
+
+    let list = Type::group_type_builder("list")
+        .with_repetition(Repetition::VECTOR)
+        .with_vector_length(Some(len))
+        .with_fields(vec![Arc::new(element_leaf)])
+        .build()?;
+
+    Type::group_type_builder(name)
+        .with_repetition(Repetition::REQUIRED)
+        .with_logical_type(Some(LogicalType::Vector))
+        .with_fields(vec![Arc::new(list)])
+        .with_id(field_id(field))
+        .build()
 }
 
 fn parse_key_value_metadata(
@@ -541,7 +709,7 @@ pub fn parquet_to_arrow_field(parquet_column: &ColumnDescriptor) -> Result<Field
             basic_info.id().to_string(),
         );
     }
-    try_add_extension_type(ret, parquet_column.self_type())
+    complex::add_extension_type(ret, parquet_column.self_type())
 }
 
 pub fn decimal_length_from_precision(precision: u8) -> usize {

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -295,6 +295,8 @@ union LogicalType {
    17: (GeometryType) Geometry
    /// A geospatial feature in the WKB format with an explicit (non-linear/non-planar) edges interpolation.
    18: (GeographyType) Geography
+   /// A fixed-size vector (fixed-size list) annotation.
+   19: Vector
 }
 );
 
@@ -359,6 +361,12 @@ enum FieldRepetitionType {
   OPTIONAL = 1;
   /// The field is repeated and can contain 0 or more values.
   REPEATED = 2;
+  /// EXPERIMENTAL: the field repeats exactly `vector_length` times per parent
+  /// value and, unlike `REPEATED`, does NOT increase the maximum definition or
+  /// repetition level of its descendants. Only valid on the middle group of the
+  /// canonical 3-level `VECTOR` logical type encoding; see
+  /// [`crate::schema::types::SchemaDescriptor`].
+  VECTOR = 3;
 }
 );
 
@@ -1043,7 +1051,7 @@ impl ColumnOrder {
                     true => SortOrder::SIGNED,
                     false => SortOrder::UNSIGNED,
                 },
-                LogicalType::Map | LogicalType::List => SortOrder::UNDEFINED,
+                LogicalType::Map | LogicalType::List | LogicalType::Vector => SortOrder::UNDEFINED,
                 LogicalType::Decimal(_) => SortOrder::SIGNED,
                 LogicalType::Date => SortOrder::SIGNED,
                 LogicalType::Time(_) => SortOrder::SIGNED,
@@ -1242,6 +1250,7 @@ impl From<Option<LogicalType>> for ConvertedType {
                 | LogicalType::Variant(_)
                 | LogicalType::Geometry(_)
                 | LogicalType::Geography(_)
+                | LogicalType::Vector
                 | LogicalType::_Unknown { .. }
                 | LogicalType::Unknown => ConvertedType::NONE,
             },
@@ -1261,6 +1270,7 @@ impl str::FromStr for Repetition {
             "REQUIRED" => Ok(Repetition::REQUIRED),
             "OPTIONAL" => Ok(Repetition::OPTIONAL),
             "REPEATED" => Ok(Repetition::REPEATED),
+            "VECTOR" => Ok(Repetition::VECTOR),
             other => Err(general_err!("Invalid parquet repetition {}", other)),
         }
     }
@@ -1326,6 +1336,7 @@ impl str::FromStr for LogicalType {
             "INTEGER" => Ok(LogicalType::integer(8, false)),
             "MAP" => Ok(LogicalType::Map),
             "LIST" => Ok(LogicalType::List),
+            "VECTOR" => Ok(LogicalType::Vector),
             "ENUM" => Ok(LogicalType::Enum),
             "DECIMAL" => Ok(LogicalType::decimal(-1, -1)),
             "DATE" => Ok(LogicalType::Date),
@@ -1745,6 +1756,10 @@ mod tests {
             ConvertedType::MAP
         );
         assert_eq!(
+            ConvertedType::from(Some(LogicalType::Vector)),
+            ConvertedType::NONE
+        );
+        assert_eq!(
             ConvertedType::from(Some(LogicalType::Uuid)),
             ConvertedType::NONE
         );
@@ -1779,6 +1794,7 @@ mod tests {
         test_roundtrip(LogicalType::String);
         test_roundtrip(LogicalType::Map);
         test_roundtrip(LogicalType::List);
+        test_roundtrip(LogicalType::Vector);
         test_roundtrip(LogicalType::Enum);
         test_roundtrip(LogicalType::decimal(0, 20));
         test_roundtrip(LogicalType::Date);

--- a/parquet/src/column/page.rs
+++ b/parquet/src/column/page.rs
@@ -350,6 +350,8 @@ pub struct PageMetadata {
     pub num_rows: Option<usize>,
     /// The number of levels within the page if known
     pub num_levels: Option<usize>,
+    /// The number of null values within the page if known
+    pub num_nulls: Option<usize>,
     /// Returns true if the page is a dictionary page
     pub is_dict: bool,
 }
@@ -366,12 +368,14 @@ impl TryFrom<&crate::file::metadata::thrift::PageHeader> for PageMetadata {
                 Ok(PageMetadata {
                     num_rows: None,
                     num_levels: Some(header.num_values as _),
+                    num_nulls: None,
                     is_dict: false,
                 })
             }
             PageType::DICTIONARY_PAGE => Ok(PageMetadata {
                 num_rows: None,
                 num_levels: None,
+                num_nulls: None,
                 is_dict: true,
             }),
             PageType::DATA_PAGE_V2 => {
@@ -379,6 +383,7 @@ impl TryFrom<&crate::file::metadata::thrift::PageHeader> for PageMetadata {
                 Ok(PageMetadata {
                     num_rows: Some(header.num_rows as _),
                     num_levels: Some(header.num_values as _),
+                    num_nulls: Some(header.num_nulls as _),
                     is_dict: false,
                 })
             }

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -301,12 +301,21 @@ where
 
                 // If page has less rows than the remaining records to
                 // be skipped, skip entire page
-                let rows = metadata.num_rows.or_else(|| {
-                    // If no repetition levels, num_levels == num_rows
-                    self.rep_level_decoder
-                        .is_none()
-                        .then_some(metadata.num_levels)?
-                });
+                let rows = if self.descr.vector_length().is_some() {
+                    // EXPERIMENTAL: a VECTOR column is decoded as a flat element
+                    // stream (1 value == 1 record here), so skip whole pages by the
+                    // flat element count (num_levels). The DataPageV2 header's
+                    // num_rows is the *logical* vector-row count and must not be used
+                    // for this flat skip — doing so would miscount by vector_length.
+                    metadata.num_levels
+                } else {
+                    metadata.num_rows.or_else(|| {
+                        // If no repetition levels, num_levels == num_rows
+                        self.rep_level_decoder
+                            .is_none()
+                            .then_some(metadata.num_levels)?
+                    })
+                };
 
                 if let Some(rows) = rows {
                     if rows <= remaining_records {

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -479,6 +479,9 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         let compressor = create_codec(codec, &codec_options).unwrap();
         let encoder = E::try_new(&descr, props.as_ref()).unwrap();
 
+        // VECTOR columns keep the standard Parquet statistics semantics: page and
+        // column statistics describe the primitive element values, not whole vector
+        // rows.
         let statistics_enabled = props.statistics_enabled(descr.path());
 
         let mut encodings = BTreeSet::new();
@@ -569,6 +572,21 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             value_indices.map_or(values.len(), |i| i.len())
         };
 
+        // EXPERIMENTAL: a VECTOR column is written as whole vectors (each record is
+        // `vector_length` contiguous values with no levels). Reject a batch that
+        // is not a whole number of vectors, so page boundaries stay vector-aligned
+        // and the row count (`num_levels / vector_length`) is exact.
+        if let Some(n) = self.descr.vector_length() {
+            let n = n as usize;
+            if num_levels % n != 0 {
+                return Err(general_err!(
+                    "VECTOR column write must contain whole vectors: {} values is not a multiple of vector_length {}",
+                    num_levels,
+                    n
+                ));
+            }
+        }
+
         if let Some(min) = min {
             update_min(&self.descr, min, &mut self.column_metrics.min_column_value);
         }
@@ -597,6 +615,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         } else {
             self.props.write_batch_size()
         };
+        // EXPERIMENTAL: for a VECTOR column, keep every data page on a whole-vector
+        // boundary. Each record is `vector_length` contiguous values with no
+        // levels, so mini-batch (and therefore page) boundaries must fall on a
+        // multiple of `vector_length`.
+        let vector_length = self.descr.vector_length().map(|n| n as usize);
         let chunker = ByteBudgetChunker::new(&self.descr, &self.props, base_batch_size);
         while levels_offset < num_levels {
             let mut end_offset = num_levels.min(levels_offset + base_batch_size);
@@ -605,6 +628,14 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             if let LevelDataRef::Materialized(levels) = rep_levels {
                 while end_offset < levels.len() && levels[end_offset] != 0 {
                     end_offset += 1;
+                }
+            }
+
+            // Align the mini-batch boundary to a whole vector, guaranteeing at
+            // least one full vector of forward progress.
+            if let Some(n) = vector_length {
+                if end_offset < num_levels {
+                    end_offset = (end_offset - end_offset % n).max(levels_offset + n);
                 }
             }
 
@@ -626,6 +657,16 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                 values_offset,
                 chunk_size,
             );
+
+            // For a VECTOR column, skip byte-budget sub-batching so the page only
+            // ever flushes on the vector-aligned mini-batch boundary above. The
+            // whole mini-batch is at most `base_batch_size` (or one vector)
+            // values, and `should_add_data_page` still bounds the page by size.
+            let sub_batch_size = if vector_length.is_some() {
+                chunk_size
+            } else {
+                sub_batch_size
+            };
 
             if sub_batch_size >= chunk_size {
                 values_offset += self.write_mini_batch(
@@ -798,10 +839,14 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
         let offset_index = self.offset_index_builder.map(|b| b.build());
 
+        // Bloom filters, like statistics, are over primitive element values for
+        // VECTOR columns.
+        let bloom_filter = self.encoder.flush_bloom_filter();
+
         Ok(ColumnCloseResult {
             bytes_written: self.column_metrics.total_bytes_written,
             rows_written: self.column_metrics.total_rows_written,
-            bloom_filter: self.encoder.flush_bloom_filter(),
+            bloom_filter,
             metadata,
             column_index,
             offset_index,
@@ -987,6 +1032,12 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                 }
             }
             self.page_metrics.num_buffered_rows += new_rows;
+        } else if let Some(n) = self.descr.vector_length() {
+            // EXPERIMENTAL: a VECTOR column stores exactly `vector_length` values
+            // per row with no levels, so each record spans `n` contiguous values.
+            // Mini-batch boundaries are aligned to multiples of `n` (see
+            // `write_batch_internal`), so this division is exact.
+            self.page_metrics.num_buffered_rows += (num_levels / n as usize) as u32;
         } else {
             // Each value is exactly one row.
             // Equals to the number of values, we count nulls as well.
@@ -1954,6 +2005,41 @@ mod tests {
                 "Parquet error: Expected to write 4 values, but have only 2"
             );
         }
+    }
+
+    #[test]
+    fn test_column_writer_vector_requires_whole_vectors() {
+        use crate::schema::types::{ColumnDescriptor, ColumnPath, Type as SchemaType};
+
+        let page_writer = get_test_page_writer();
+        let props = Default::default();
+        // VECTOR FLOAT element leaf with vector_length 3 carried by its parent
+        // VECTOR-repeated group.
+        let tpe = SchemaType::primitive_type_builder("element", crate::basic::Type::FLOAT)
+            .with_repetition(crate::basic::Repetition::REQUIRED)
+            .build()
+            .unwrap();
+        let descr = Arc::new(ColumnDescriptor::new_with_repeated_ancestor_and_vector(
+            Arc::new(tpe),
+            0,
+            0,
+            ColumnPath::new(vec![
+                "v".to_string(),
+                "list".to_string(),
+                "element".to_string(),
+            ]),
+            0,
+            Some(3),
+        ));
+        let column_writer = get_column_writer(descr, props, page_writer);
+        let mut writer = get_typed_column_writer::<FloatType>(column_writer);
+
+        // 4 values is not a whole number of 3-element vectors.
+        let err = writer
+            .write_batch(&[1.0, 2.0, 3.0, 4.0], None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("whole vectors"), "unexpected error: {err}");
     }
 
     #[test]

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -2046,10 +2046,11 @@ mod tests {
             .set_row_groups(row_group_meta_with_stats)
             .build();
 
+        // VECTOR metadata adds small `Option<i32>` fields to schema nodes.
         #[cfg(not(feature = "encryption"))]
-        let base_expected_size = 2734;
+        let base_expected_size = 2774;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2902;
+        let base_expected_size = 2942;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -2077,10 +2078,11 @@ mod tests {
             .set_offset_index(Some(vec![vec![offset_index]]))
             .build();
 
+        // Includes VECTOR metadata fields on schema nodes, as above.
         #[cfg(not(feature = "encryption"))]
-        let bigger_expected_size = 3160;
+        let bigger_expected_size = 3200;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3328;
+        let bigger_expected_size = 3368;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);
@@ -2127,7 +2129,8 @@ mod tests {
             .set_row_groups(row_group_meta.clone())
             .build();
 
-        let base_expected_size = 2042;
+        // Includes VECTOR metadata fields on schema nodes.
+        let base_expected_size = 2082;
         assert_eq!(parquet_meta_data.memory_size(), base_expected_size);
 
         let footer_key = "0123456789012345".as_bytes();
@@ -2153,7 +2156,7 @@ mod tests {
             .set_file_decryptor(Some(decryptor))
             .build();
 
-        let expected_size_with_decryptor = 3056;
+        let expected_size_with_decryptor = 3096;
         assert!(expected_size_with_decryptor > base_expected_size);
 
         assert_eq!(

--- a/parquet/src/file/metadata/thrift/mod.rs
+++ b/parquet/src/file/metadata/thrift/mod.rs
@@ -100,6 +100,11 @@ pub(crate) struct SchemaElement<'a> {
   /// LogicalType replaces ConvertedType, but ConvertedType is still required
   /// for some logical types to ensure forward-compatibility in format v1.
   10: optional LogicalType logical_type
+  /// EXPERIMENTAL: the fixed number of element slots per parent occurrence when
+  /// `repetition_type` is `VECTOR`. MUST be set and positive when the repetition
+  /// is `VECTOR`, and MUST NOT be set otherwise. Field id 11 matches the
+  /// apache/parquet-format VECTOR proposal.
+  11: optional i32 vector_length
 }
 );
 
@@ -1530,10 +1535,15 @@ fn write_schema_helper<W: Write>(
                     None
                 },
                 logical_type: basic_info.logical_type_ref().cloned(),
+                vector_length: None,
             };
             element.write_thrift(writer)
         }
-        crate::schema::types::Type::GroupType { basic_info, fields } => {
+        crate::schema::types::Type::GroupType {
+            basic_info,
+            fields,
+            vector_length,
+        } => {
             let repetition = if basic_info.has_repetition() {
                 Some(basic_info.repetition())
             } else {
@@ -1558,6 +1568,7 @@ fn write_schema_helper<W: Write>(
                     None
                 },
                 logical_type: basic_info.logical_type_ref().cloned(),
+                vector_length: *vector_length,
             };
 
             element.write_thrift(writer)?;

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -68,6 +68,8 @@ pub const DEFAULT_STATISTICS_TRUNCATE_LENGTH: Option<usize> = Some(64);
 pub const DEFAULT_OFFSET_INDEX_DISABLED: bool = false;
 /// Default values for [`WriterProperties::coerce_types`]
 pub const DEFAULT_COERCE_TYPES: bool = false;
+/// Default values for [`WriterProperties::vector_encoding`]
+pub const DEFAULT_VECTOR_ENCODING: bool = false;
 /// Default value for [`WriterProperties::data_page_v2_compression_ratio_threshold`]
 pub const DEFAULT_DATA_PAGE_V2_COMPRESSION_RATIO_THRESHOLD: f64 = 1.0;
 /// Default value for [`WriterProperties::write_path_in_schema`]
@@ -254,6 +256,7 @@ pub struct WriterProperties {
     column_index_truncate_length: Option<usize>,
     statistics_truncate_length: Option<usize>,
     coerce_types: bool,
+    vector_encoding: bool,
     content_defined_chunking: Option<CdcOptions>,
     write_path_in_schema: bool,
     #[cfg(feature = "encryption")]
@@ -441,6 +444,14 @@ impl WriterProperties {
         self.coerce_types
     }
 
+    /// Returns `true` if EXPERIMENTAL VECTOR encoding of eligible Arrow
+    /// `FixedSizeList` columns is enabled.
+    ///
+    /// For more details see [`WriterPropertiesBuilder::set_vector_encoding`]
+    pub fn vector_encoding(&self) -> bool {
+        self.vector_encoding
+    }
+
     /// Returns `true` if the `path_in_schema` field of the `ColumnMetaData` Thrift struct
     /// should be written.
     ///
@@ -603,6 +614,7 @@ pub struct WriterPropertiesBuilder {
     column_index_truncate_length: Option<usize>,
     statistics_truncate_length: Option<usize>,
     coerce_types: bool,
+    vector_encoding: bool,
     content_defined_chunking: Option<CdcOptions>,
     write_path_in_schema: bool,
     #[cfg(feature = "encryption")]
@@ -628,6 +640,7 @@ impl Default for WriterPropertiesBuilder {
             column_index_truncate_length: DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
             statistics_truncate_length: DEFAULT_STATISTICS_TRUNCATE_LENGTH,
             coerce_types: DEFAULT_COERCE_TYPES,
+            vector_encoding: DEFAULT_VECTOR_ENCODING,
             content_defined_chunking: None,
             write_path_in_schema: DEFAULT_WRITE_PATH_IN_SCHEMA,
             #[cfg(feature = "encryption")]
@@ -683,6 +696,7 @@ impl WriterPropertiesBuilder {
             column_index_truncate_length: self.column_index_truncate_length,
             statistics_truncate_length: self.statistics_truncate_length,
             coerce_types: self.coerce_types,
+            vector_encoding: self.vector_encoding,
             content_defined_chunking: self.content_defined_chunking,
             write_path_in_schema: self.write_path_in_schema,
             #[cfg(feature = "encryption")]
@@ -897,6 +911,48 @@ impl WriterPropertiesBuilder {
     /// [`ArrowToParquetSchemaConverter::with_coerce_types`]: crate::arrow::ArrowSchemaConverter::with_coerce_types
     pub fn set_coerce_types(mut self, coerce_types: bool) -> Self {
         self.coerce_types = coerce_types;
+        self
+    }
+
+    /// EXPERIMENTAL: enable encoding eligible Arrow `FixedSizeList` columns using
+    /// the Parquet `VECTOR` logical type / repetition type instead of the standard
+    /// 3-level `LIST` encoding. Defaults to `false` via [`DEFAULT_VECTOR_ENCODING`].
+    ///
+    /// Only a top-level, non-nullable `FixedSizeList` with a positive size and a
+    /// non-nullable fixed-width primitive element is encoded as `VECTOR`; every
+    /// other `FixedSizeList` (nullable, nested, zero-length, or with a
+    /// variable-width/nullable element) transparently falls back to the standard
+    /// `LIST` encoding.
+    ///
+    /// `VECTOR` is not yet part of apache/parquet-format and is identified on disk
+    /// by an outer `LogicalType::VECTOR` group containing a `FieldRepetitionType::VECTOR`
+    /// middle group with `SchemaElement::vector_length`. Files written with `VECTOR`
+    /// are **not** readable by Parquet implementations that do not understand the
+    /// `VECTOR` repetition type. Only enable this for consumers known to support it.
+    ///
+    /// This writer keeps every data page on a whole-vector boundary, and the reader
+    /// requires that invariant: a `VECTOR` column whose page splits a vector value
+    /// is rejected on read. Interop is therefore guaranteed only with writers that
+    /// also align pages to vector boundaries.
+    ///
+    /// Note: page/column statistics (min/max/null_count), page-index bounds, and
+    /// bloom filters are computed over the flattened *element* values, not over
+    /// whole vector values.
+    ///
+    /// When read back without the embedded Arrow schema (self-describing), the
+    /// reconstructed `FixedSizeList` child field is named `"element"` (matching the
+    /// Parquet LIST element convention and the Option B proposal). With the
+    /// embedded Arrow schema present, the original child field name is preserved.
+    ///
+    /// Performance: row-level skipping (`RowSelection` / predicate pushdown) over a
+    /// VECTOR column delegates to the leaf column reader. When page metadata carries
+    /// the required value counts, whole pages are skipped without decoding and only
+    /// the residual within a partially-selected page is skipped at the decoder level
+    /// — the same characteristics as an ordinary column. If offset-index metadata is
+    /// incomplete, the reader may read the page to validate VECTOR invariants before
+    /// deciding whether it can be skipped.
+    pub fn set_vector_encoding(mut self, vector_encoding: bool) -> Self {
+        self.vector_encoding = vector_encoding;
         self
     }
 
@@ -1346,6 +1402,7 @@ impl From<WriterProperties> for WriterPropertiesBuilder {
             column_index_truncate_length: props.column_index_truncate_length,
             statistics_truncate_length: props.statistics_truncate_length,
             coerce_types: props.coerce_types,
+            vector_encoding: props.vector_encoding,
             content_defined_chunking: props.content_defined_chunking,
             write_path_in_schema: props.write_path_in_schema,
             #[cfg(feature = "encryption")]

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1071,6 +1071,7 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                     Ok(Some(PageMetadata {
                         num_rows: None,
                         num_levels: None,
+                        num_nulls: None,
                         is_dict: true,
                     }))
                 } else if let Some(page) = page_locations.front() {
@@ -1082,6 +1083,7 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                     Ok(Some(PageMetadata {
                         num_rows: Some(next_rows - page.first_row_index as usize),
                         num_levels: None,
+                        num_nulls: None,
                         is_dict: false,
                     }))
                 } else {

--- a/parquet/src/record/reader.rs
+++ b/parquet/src/record/reader.rs
@@ -115,6 +115,16 @@ impl TreeBuilder {
         assert!(field.get_basic_info().has_repetition());
         // Update current definition and repetition levels for this type
         let repetition = field.get_basic_info().repetition();
+        // EXPERIMENTAL: the row-based record API has no fixed-size-list concept and
+        // would read a VECTOR column as one element per row, silently corrupting
+        // output. Reject VECTOR columns explicitly; use the Arrow reader instead.
+        if repetition == Repetition::VECTOR {
+            return Err(general_err!(
+                "Reading VECTOR columns is not supported by the record (row) API; \
+                 use the Arrow reader instead (column '{}')",
+                field.name()
+            ));
+        }
         match repetition {
             Repetition::OPTIONAL => {
                 curr_def_level += 1;

--- a/parquet/src/schema/parser.rs
+++ b/parquet/src/schema/parser.rs
@@ -84,7 +84,15 @@ impl<'a> Tokenizer<'a> {
 
     // List of all special characters in schema
     fn is_schema_delim(c: char) -> bool {
-        c == ';' || c == '{' || c == '}' || c == '(' || c == ')' || c == '=' || c == ','
+        c == ';'
+            || c == '{'
+            || c == '}'
+            || c == '('
+            || c == ')'
+            || c == '='
+            || c == ','
+            || c == '['
+            || c == ']'
     }
 
     /// Splits string into tokens; input string can already be token or can contain
@@ -244,43 +252,71 @@ impl Parser<'_> {
             .next()
             .ok_or_else(|| general_err!("Expected name, found None"))?;
 
-        // Parse logical or converted type if exists
-        let (logical_type, converted_type) = if let Some("(") = self.tokenizer.next() {
-            let tpe = self
-                .tokenizer
-                .next()
-                .ok_or_else(|| general_err!("Expected converted type, found None"))
-                .and_then(|v| {
-                    // Try logical type first
-                    let upper = v.to_uppercase();
-                    let logical = upper.parse::<LogicalType>();
-                    match logical {
-                        Ok(logical) => {
-                            Ok((Some(logical.clone()), ConvertedType::from(Some(logical))))
-                        }
-                        Err(_) => Ok((None, upper.parse::<ConvertedType>()?)),
-                    }
-                })?;
-            assert_token(self.tokenizer.next(), ")")?;
-            tpe
+        // A VECTOR-repeated middle group carries its fixed length after the name,
+        // e.g. `VECTOR group list [768] { ... }`.
+        let vector_length = if repetition == Some(Repetition::VECTOR) {
+            assert_token(self.tokenizer.next(), "[")?;
+            let n = parse_i32(
+                self.tokenizer.next(),
+                "Expected vector length, found None",
+                "Failed to parse vector length for VECTOR repetition",
+            )?;
+            assert_token(self.tokenizer.next(), "]")?;
+            Some(n)
         } else {
-            self.tokenizer.backtrack();
-            (None, ConvertedType::NONE)
-        };
-
-        // Parse optional id
-        let id = if let Some("=") = self.tokenizer.next() {
-            self.tokenizer.next().and_then(|v| v.parse::<i32>().ok())
-        } else {
-            self.tokenizer.backtrack();
             None
         };
+
+        // Parse optional logical/converted type and optional id. The printer emits
+        // group ids before logical types (`group f [1] (LIST)`), while existing
+        // parser inputs may use logical-before-id (`group f (LIST) [1]`), so accept
+        // either order.
+        let mut logical_type = None;
+        let mut converted_type = ConvertedType::NONE;
+        let mut id = None;
+        loop {
+            match self.tokenizer.next() {
+                Some("(") if logical_type.is_none() && converted_type == ConvertedType::NONE => {
+                    let tpe = self
+                        .tokenizer
+                        .next()
+                        .ok_or_else(|| general_err!("Expected converted type, found None"))
+                        .and_then(|v| {
+                            // Try logical type first
+                            let upper = v.to_uppercase();
+                            let logical = upper.parse::<LogicalType>();
+                            match logical {
+                                Ok(logical) => {
+                                    Ok((Some(logical.clone()), ConvertedType::from(Some(logical))))
+                                }
+                                Err(_) => Ok((None, upper.parse::<ConvertedType>()?)),
+                            }
+                        })?;
+                    assert_token(self.tokenizer.next(), ")")?;
+                    logical_type = tpe.0;
+                    converted_type = tpe.1;
+                }
+                Some("=") if id.is_none() => {
+                    id = self.tokenizer.next().and_then(|v| v.parse::<i32>().ok());
+                }
+                Some("[") if id.is_none() => {
+                    id = self.tokenizer.next().and_then(|v| v.parse::<i32>().ok());
+                    assert_token(self.tokenizer.next(), "]")?;
+                }
+                Some(_) => {
+                    self.tokenizer.backtrack();
+                    break;
+                }
+                None => break,
+            }
+        }
 
         let mut builder = Type::group_type_builder(name)
             .with_logical_type(logical_type)
             .with_converted_type(converted_type)
             .with_fields(self.parse_child_types()?)
-            .with_id(id);
+            .with_id(id)
+            .with_vector_length(vector_length);
         if let Some(rep) = repetition {
             builder = builder.with_repetition(rep);
         }
@@ -310,10 +346,26 @@ impl Parser<'_> {
             .next()
             .ok_or_else(|| general_err!("Expected name, found None"))?;
 
+        // Parse optional id before logical/converted type. The printer emits
+        // primitive ids before logical annotations (`INT32 f [1] (INT_32)`),
+        // while existing parser inputs may use logical-before-id.
+        let mut id = None;
+        let mut next = self.tokenizer.next();
+        match next {
+            Some("=") => {
+                id = self.tokenizer.next().and_then(|v| v.parse::<i32>().ok());
+                next = self.tokenizer.next();
+            }
+            Some("[") => {
+                id = self.tokenizer.next().and_then(|v| v.parse::<i32>().ok());
+                assert_token(self.tokenizer.next(), "]")?;
+                next = self.tokenizer.next();
+            }
+            _ => {}
+        }
+
         // Parse converted type
-        let (logical_type, converted_type, precision, scale) = if let Some("(") =
-            self.tokenizer.next()
-        {
+        let (logical_type, converted_type, precision, scale) = if next == Some("(") {
             let (mut logical, mut converted) = self
                 .tokenizer
                 .next()
@@ -485,13 +537,22 @@ impl Parser<'_> {
             (None, ConvertedType::NONE, -1, -1)
         };
 
-        // Parse optional id
-        let id = if let Some("=") = self.tokenizer.next() {
-            self.tokenizer.next().and_then(|v| v.parse::<i32>().ok())
-        } else {
-            self.tokenizer.backtrack();
-            None
-        };
+        // Parse optional id after logical/converted type (both `= 1` and
+        // printer-style `[1]` are accepted).
+        if id.is_none() {
+            id = match self.tokenizer.next() {
+                Some("=") => self.tokenizer.next().and_then(|v| v.parse::<i32>().ok()),
+                Some("[") => {
+                    let id = self.tokenizer.next().and_then(|v| v.parse::<i32>().ok());
+                    assert_token(self.tokenizer.next(), "]")?;
+                    id
+                }
+                _ => {
+                    self.tokenizer.backtrack();
+                    None
+                }
+            };
+        }
         assert_token(self.tokenizer.next(), ";")?;
 
         Type::primitive_type_builder(name, physical_type)
@@ -517,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_delimiters() {
-        let mut iter = Tokenizer::from_str(",;{}()=");
+        let mut iter = Tokenizer::from_str(",;{}()=[]");
         assert_eq!(iter.next(), Some(","));
         assert_eq!(iter.next(), Some(";"));
         assert_eq!(iter.next(), Some("{"));
@@ -525,12 +586,14 @@ mod tests {
         assert_eq!(iter.next(), Some("("));
         assert_eq!(iter.next(), Some(")"));
         assert_eq!(iter.next(), Some("="));
+        assert_eq!(iter.next(), Some("["));
+        assert_eq!(iter.next(), Some("]"));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_tokenize_delimiters_with_whitespaces() {
-        let mut iter = Tokenizer::from_str(" , ; { } ( ) = ");
+        let mut iter = Tokenizer::from_str(" , ; { } ( ) = [ ] ");
         assert_eq!(iter.next(), Some(","));
         assert_eq!(iter.next(), Some(";"));
         assert_eq!(iter.next(), Some("{"));
@@ -538,6 +601,8 @@ mod tests {
         assert_eq!(iter.next(), Some("("));
         assert_eq!(iter.next(), Some(")"));
         assert_eq!(iter.next(), Some("="));
+        assert_eq!(iter.next(), Some("["));
+        assert_eq!(iter.next(), Some("]"));
         assert_eq!(iter.next(), None);
     }
 
@@ -1089,5 +1154,66 @@ mod tests {
             .build()
             .unwrap();
         assert_eq!(message, expected);
+    }
+
+    #[test]
+    fn test_parse_and_print_vector() {
+        use crate::schema::printer::print_schema;
+
+        let schema_str = "
+        message schema {
+            REQUIRED group embedding (VECTOR) [42] {
+              VECTOR group list [768] {
+                REQUIRED FLOAT element;
+              }
+            }
+            REQUIRED INT32 id;
+        }
+        ";
+        let parsed = parse_message_type(schema_str).unwrap();
+        let vector = &parsed.get_fields()[0];
+        assert_eq!(
+            vector.get_basic_info().logical_type_ref(),
+            Some(&LogicalType::Vector)
+        );
+        assert_eq!(vector.get_basic_info().id(), 42);
+        let list = &vector.get_fields()[0];
+        assert_eq!(list.get_basic_info().repetition(), Repetition::VECTOR);
+        assert_eq!(list.vector_length(), Some(768));
+
+        // The printed schema must round-trip back through the parser.
+        let mut buf = Vec::new();
+        print_schema(&mut buf, &parsed);
+        let printed = String::from_utf8(buf).unwrap();
+        let reparsed = parse_message_type(&printed).unwrap();
+        assert_eq!(parsed, reparsed);
+
+        // An FLBA element prints both the VECTOR length and the FLBA type length.
+        let flba = parse_message_type(
+            "message schema { REQUIRED group ids (VECTOR) { VECTOR group list [4] { REQUIRED FIXED_LEN_BYTE_ARRAY (16) element; } } }",
+        )
+        .unwrap();
+        let list = &flba.get_fields()[0].get_fields()[0];
+        assert_eq!(list.vector_length(), Some(4));
+        match list.get_fields()[0].as_ref() {
+            Type::PrimitiveType { type_length, .. } => assert_eq!(*type_length, 16),
+            _ => panic!("expected a primitive VECTOR element"),
+        }
+        let mut buf = Vec::new();
+        print_schema(&mut buf, &flba);
+        let reparsed = parse_message_type(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(flba, reparsed);
+
+        // Primitive element ids printed before logical annotations also round-trip.
+        let id_before_logical = parse_message_type(
+            "message schema { REQUIRED group v (VECTOR) { VECTOR group list [2] { REQUIRED INT32 element [7] (INT_32); } } }",
+        )
+        .unwrap();
+        let element = &id_before_logical.get_fields()[0].get_fields()[0].get_fields()[0];
+        assert_eq!(element.get_basic_info().id(), 7);
+        let mut buf = Vec::new();
+        print_schema(&mut buf, &id_before_logical);
+        let reparsed = parse_message_type(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(id_before_logical, reparsed);
     }
 }

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -318,6 +318,7 @@ fn print_logical_and_converted(
             LogicalType::Enum => "ENUM".to_string(),
             LogicalType::List => "LIST".to_string(),
             LogicalType::Map => "MAP".to_string(),
+            LogicalType::Vector => "VECTOR".to_string(),
             LogicalType::Float16 => "FLOAT16".to_string(),
             LogicalType::Variant(VariantType {
                 specification_version,
@@ -384,10 +385,11 @@ impl Printer<'_> {
                     }
                     _ => format!("{physical_type}"),
                 };
+                let repetition_str = format!("{}", basic_info.repetition());
                 write!(
                     self.output,
                     "{} {} {}",
-                    basic_info.repetition(),
+                    repetition_str,
                     phys_type_str,
                     basic_info.name()
                 );
@@ -411,6 +413,7 @@ impl Printer<'_> {
             Type::GroupType {
                 ref basic_info,
                 ref fields,
+                vector_length,
             } => {
                 if basic_info.has_repetition() {
                     write!(
@@ -419,6 +422,9 @@ impl Printer<'_> {
                         basic_info.repetition(),
                         basic_info.name()
                     );
+                    if let Some(n) = vector_length {
+                        write!(self.output, "[{n}] ");
+                    }
                     if basic_info.has_id() {
                         write!(self.output, "[{}] ", basic_info.id());
                     }

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -66,6 +66,10 @@ pub enum Type {
         basic_info: BasicTypeInfo,
         /// Fields of this group type.
         fields: Vec<TypePtr>,
+        /// EXPERIMENTAL: number of element slots per parent occurrence when this
+        /// group has `Repetition::VECTOR`. `Some(n)` with `n > 0` iff the
+        /// repetition is `VECTOR`; `None` otherwise.
+        vector_length: Option<i32>,
     },
 }
 
@@ -73,7 +77,9 @@ impl HeapSize for Type {
     fn heap_size(&self) -> usize {
         match self {
             Type::PrimitiveType { basic_info, .. } => basic_info.heap_size(),
-            Type::GroupType { basic_info, fields } => basic_info.heap_size() + fields.heap_size(),
+            Type::GroupType {
+                basic_info, fields, ..
+            } => basic_info.heap_size() + fields.heap_size(),
         }
     }
 }
@@ -203,9 +209,14 @@ impl Type {
 
     /// Returns `true` if this type is repeated or optional.
     /// If this type doesn't have repetition defined, we treat it as required.
+    /// `VECTOR` repetition itself contributes no nullability; nullable vectors are
+    /// represented by the outer `LogicalType::Vector` group.
     pub fn is_optional(&self) -> bool {
         self.get_basic_info().has_repetition()
-            && self.get_basic_info().repetition() != Repetition::REQUIRED
+            && matches!(
+                self.get_basic_info().repetition(),
+                Repetition::OPTIONAL | Repetition::REPEATED
+            )
     }
 
     /// Returns `true` if this type is annotated as a list.
@@ -229,6 +240,15 @@ impl Type {
                 && children[0].get_basic_info().repetition() == Repetition::REPEATED;
         }
         false
+    }
+
+    /// EXPERIMENTAL: returns the fixed vector length when this type is a
+    /// `Repetition::VECTOR` group, or `None` otherwise.
+    pub fn vector_length(&self) -> Option<i32> {
+        match self {
+            Type::PrimitiveType { .. } => None,
+            Type::GroupType { vector_length, .. } => *vector_length,
+        }
     }
 }
 
@@ -349,7 +369,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
             }
             // Check that logical type and physical type are compatible
             match (logical_type, self.physical_type) {
-                (LogicalType::Map, _) | (LogicalType::List, _) => {
+                (LogicalType::Map, _) | (LogicalType::List, _) | (LogicalType::Vector, _) => {
                     return Err(general_err!(
                         "{:?} cannot be applied to a primitive type for field '{}'",
                         logical_type,
@@ -498,6 +518,14 @@ impl<'a> PrimitiveTypeBuilder<'a> {
             }
         }
 
+        // EXPERIMENTAL: the canonical VECTOR encoding carries VECTOR repetition
+        // and vector_length on a middle group, not on the primitive leaf.
+        if self.repetition == Repetition::VECTOR {
+            return Err(general_err!(
+                "VECTOR repetition is only valid on group fields, not primitive field '{}'",
+                self.name
+            ));
+        }
         Ok(Type::PrimitiveType {
             basic_info,
             physical_type: self.physical_type,
@@ -595,6 +623,7 @@ pub struct GroupTypeBuilder<'a> {
     logical_type: Option<LogicalType>,
     fields: Vec<TypePtr>,
     id: Option<i32>,
+    vector_length: Option<i32>,
 }
 
 impl<'a> GroupTypeBuilder<'a> {
@@ -607,6 +636,7 @@ impl<'a> GroupTypeBuilder<'a> {
             logical_type: None,
             fields: Vec::new(),
             id: None,
+            vector_length: None,
         }
     }
 
@@ -643,8 +673,45 @@ impl<'a> GroupTypeBuilder<'a> {
         Self { id, ..self }
     }
 
+    /// EXPERIMENTAL: sets the fixed vector length for a `Repetition::VECTOR`
+    /// group and returns itself. Must be `Some(n)` with `n > 0` when the
+    /// repetition is `VECTOR`, and `None` otherwise.
+    pub fn with_vector_length(self, vector_length: Option<i32>) -> Self {
+        Self {
+            vector_length,
+            ..self
+        }
+    }
+
     /// Creates a new `GroupType` instance from the gathered attributes.
     pub fn build(self) -> Result<Type> {
+        match self.repetition {
+            Some(Repetition::VECTOR) => validate_vector_group(
+                self.name,
+                self.vector_length,
+                self.converted_type,
+                self.logical_type.as_ref(),
+                &self.fields,
+            )?,
+            _ => {
+                if self.vector_length.is_some() {
+                    return Err(general_err!(
+                        "vector_length can only be set on a VECTOR repetition group '{}'",
+                        self.name
+                    ));
+                }
+            }
+        }
+
+        if matches!(self.logical_type, Some(LogicalType::Vector)) {
+            validate_vector_logical_group(
+                self.name,
+                self.repetition,
+                self.converted_type,
+                &self.fields,
+            )?;
+        }
+
         let mut basic_info = BasicTypeInfo {
             name: String::from(self.name),
             repetition: self.repetition,
@@ -659,8 +726,116 @@ impl<'a> GroupTypeBuilder<'a> {
         Ok(Type::GroupType {
             basic_info,
             fields: self.fields,
+            vector_length: self.vector_length,
         })
     }
+}
+
+fn validate_vector_group(
+    name: &str,
+    vector_length: Option<i32>,
+    converted_type: ConvertedType,
+    logical_type: Option<&LogicalType>,
+    fields: &[TypePtr],
+) -> Result<()> {
+    match vector_length {
+        Some(n) if n > 0 => {}
+        _ => {
+            return Err(general_err!(
+                "VECTOR repetition requires a positive vector_length for group '{}'",
+                name
+            ));
+        }
+    }
+
+    if converted_type != ConvertedType::NONE || logical_type.is_some() {
+        return Err(general_err!(
+            "VECTOR repetition group '{}' must not have a logical or converted type",
+            name
+        ));
+    }
+
+    if fields.len() != 1 || fields[0].name() != "element" {
+        return Err(general_err!(
+            "VECTOR repetition group '{}' must have exactly one child named 'element'",
+            name
+        ));
+    }
+
+    validate_vector_element_subtree(fields[0].as_ref())
+}
+
+fn validate_vector_element_subtree(element: &Type) -> Result<()> {
+    if !element.is_primitive() {
+        return Err(general_err!(
+            "VECTOR element '{}' must be a primitive field",
+            element.name()
+        ));
+    }
+    if !element.get_basic_info().has_repetition() {
+        return Err(general_err!("VECTOR element must have a repetition"));
+    }
+    if element.get_basic_info().repetition() != Repetition::REQUIRED {
+        return Err(general_err!(
+            "VECTOR element '{}' must be required, not {}",
+            element.name(),
+            element.get_basic_info().repetition()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_vector_logical_group(
+    name: &str,
+    repetition: Option<Repetition>,
+    converted_type: ConvertedType,
+    fields: &[TypePtr],
+) -> Result<()> {
+    match repetition {
+        Some(Repetition::REQUIRED | Repetition::OPTIONAL) => {}
+        Some(other) => {
+            return Err(general_err!(
+                "VECTOR logical type group '{}' must be required or optional, not {}",
+                name,
+                other
+            ));
+        }
+        None => {
+            return Err(general_err!(
+                "VECTOR logical type cannot annotate root group '{}'",
+                name
+            ));
+        }
+    }
+
+    if converted_type != ConvertedType::NONE {
+        return Err(general_err!(
+            "VECTOR logical type group '{}' must not have a converted type",
+            name
+        ));
+    }
+
+    if fields.len() != 1 || fields[0].name() != "list" {
+        return Err(general_err!(
+            "VECTOR logical type group '{}' must have exactly one child named 'list'",
+            name
+        ));
+    }
+
+    let list = fields[0].as_ref();
+    if !list.is_group() || list.get_basic_info().repetition() != Repetition::VECTOR {
+        return Err(general_err!(
+            "VECTOR logical type group '{}' must contain a VECTOR-repeated group named 'list'",
+            name
+        ));
+    }
+    if list.vector_length().is_none() {
+        return Err(general_err!(
+            "VECTOR logical type group '{}' has a list child without vector_length",
+            name
+        ));
+    }
+    Ok(())
 }
 
 /// Basic type info. This contains information such as the name of the type,
@@ -857,6 +1032,9 @@ pub struct ColumnDescriptor {
 
     /// The path of this column. For instance, "a.b.c.d".
     path: ColumnPath,
+
+    /// The fixed vector length if this leaf is inside a VECTOR-repeated group.
+    vector_length: Option<i32>,
 }
 
 impl HeapSize for ColumnDescriptor {
@@ -885,12 +1063,31 @@ impl ColumnDescriptor {
         path: ColumnPath,
         repeated_ancestor_def_level: i16,
     ) -> Self {
+        Self::new_with_repeated_ancestor_and_vector(
+            primitive_type,
+            max_def_level,
+            max_rep_level,
+            path,
+            repeated_ancestor_def_level,
+            None,
+        )
+    }
+
+    pub(crate) fn new_with_repeated_ancestor_and_vector(
+        primitive_type: TypePtr,
+        max_def_level: i16,
+        max_rep_level: i16,
+        path: ColumnPath,
+        repeated_ancestor_def_level: i16,
+        vector_length: Option<i32>,
+    ) -> Self {
         Self {
             primitive_type,
             max_def_level,
             max_rep_level,
             repeated_ancestor_def_level,
             path,
+            vector_length,
         }
     }
 
@@ -974,6 +1171,12 @@ impl ColumnDescriptor {
             Type::PrimitiveType { type_length, .. } => *type_length,
             _ => panic!("Expected primitive type!"),
         }
+    }
+
+    /// EXPERIMENTAL: returns the fixed vector length when this column is inside
+    /// the canonical 3-level `VECTOR` encoding, or `None` for ordinary columns.
+    pub fn vector_length(&self) -> Option<i32> {
+        self.vector_length
     }
 
     /// Returns type precision for this column.
@@ -1097,6 +1300,7 @@ impl SchemaDescriptor {
                 &mut leaves,
                 &mut leaf_to_base,
                 &mut path,
+                None,
             );
         }
 
@@ -1229,6 +1433,7 @@ fn build_tree<'a>(
     leaves: &mut Vec<ColumnDescPtr>,
     leaf_to_base: &mut Vec<usize>,
     path_so_far: &mut Vec<&'a str>,
+    mut vector_length: Option<i32>,
 ) {
     assert!(tp.get_basic_info().has_repetition());
 
@@ -1242,19 +1447,23 @@ fn build_tree<'a>(
             max_rep_level += 1;
             repeated_ancestor_def_level = max_def_level;
         }
-        _ => {}
+        Repetition::VECTOR => {
+            vector_length = tp.vector_length();
+        }
+        Repetition::REQUIRED => {}
     }
 
     match tp.as_ref() {
         Type::PrimitiveType { .. } => {
             let mut path: Vec<String> = vec![];
             path.extend(path_so_far.iter().copied().map(String::from));
-            let desc = ColumnDescriptor::new_with_repeated_ancestor(
+            let desc = ColumnDescriptor::new_with_repeated_ancestor_and_vector(
                 tp.clone(),
                 max_def_level,
                 max_rep_level,
                 ColumnPath::new(path),
                 repeated_ancestor_def_level,
+                vector_length,
             );
             leaves.push(Arc::new(desc));
             leaf_to_base.push(root_idx);
@@ -1270,6 +1479,7 @@ fn build_tree<'a>(
                     leaves,
                     leaf_to_base,
                     path_so_far,
+                    vector_length,
                 );
                 path_so_far.pop();
             }
@@ -1340,7 +1550,7 @@ fn schema_from_array_helper<'a>(
     // Check for empty schema
     if let (true, None | Some(0)) = (is_root_node, element.num_children) {
         let builder = Type::group_type_builder(element.name);
-        return Ok((index + 1, Arc::new(builder.build().unwrap())));
+        return Ok((index + 1, Arc::new(builder.build()?)));
     }
 
     let converted_type = element.converted_type.unwrap_or(ConvertedType::NONE);
@@ -1366,6 +1576,12 @@ fn schema_from_array_helper<'a>(
             }
             let repetition = element.repetition_type.unwrap();
             if let Some(physical_type) = element.r#type {
+                if element.vector_length.is_some() {
+                    return Err(general_err!(
+                        "vector_length can only be set on a VECTOR repetition group '{}'",
+                        element.name
+                    ));
+                }
                 let length = element.type_length.unwrap_or(-1);
                 let scale = element.scale.unwrap_or(-1);
                 let precision = element.precision.unwrap_or(-1);
@@ -1383,7 +1599,8 @@ fn schema_from_array_helper<'a>(
                 let mut builder = Type::group_type_builder(element.name)
                     .with_converted_type(converted_type)
                     .with_logical_type(logical_type)
-                    .with_id(field_id);
+                    .with_id(field_id)
+                    .with_vector_length(element.vector_length);
                 if !is_root_node {
                     // Sometimes parquet-cpp and parquet-mr set repetition level REQUIRED or
                     // REPEATED for root node.
@@ -1394,7 +1611,7 @@ fn schema_from_array_helper<'a>(
                     //   All other types must have one.
                     builder = builder.with_repetition(repetition);
                 }
-                Ok((index + 1, Arc::new(builder.build().unwrap())))
+                Ok((index + 1, Arc::new(builder.build()?)))
             }
         }
         Some(n) => {
@@ -1412,7 +1629,8 @@ fn schema_from_array_helper<'a>(
                 .with_converted_type(converted_type)
                 .with_logical_type(logical_type)
                 .with_fields(fields)
-                .with_id(field_id);
+                .with_id(field_id)
+                .with_vector_length(element.vector_length);
 
             // Sometimes parquet-cpp and parquet-mr set repetition level REQUIRED or
             // REPEATED for root node.
@@ -1771,6 +1989,152 @@ mod tests {
             .with_logical_type(Some(LogicalType::_Unknown { field_id: 100 }))
             .build();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_vector_repetition_validation() {
+        let element = Arc::new(
+            Type::primitive_type_builder("element", PhysicalType::FLOAT)
+                .with_repetition(Repetition::REQUIRED)
+                .build()
+                .unwrap(),
+        );
+
+        // Valid: VECTOR-repeated middle group with a positive vector_length.
+        let list = Type::group_type_builder("list")
+            .with_repetition(Repetition::VECTOR)
+            .with_vector_length(Some(3))
+            .with_fields(vec![element.clone()])
+            .build()
+            .unwrap();
+        assert_eq!(list.vector_length(), Some(3));
+        assert!(!list.is_optional());
+
+        // VECTOR requires a positive vector_length.
+        assert!(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::VECTOR)
+                .with_fields(vec![element.clone()])
+                .build()
+                .unwrap_err()
+                .to_string()
+                .contains("positive vector_length")
+        );
+
+        // VECTOR is rejected on primitive leaf fields.
+        assert!(
+            Type::primitive_type_builder("element", PhysicalType::FLOAT)
+                .with_repetition(Repetition::VECTOR)
+                .build()
+                .unwrap_err()
+                .to_string()
+                .contains("only valid on group")
+        );
+
+        // VECTOR element must be a required primitive leaf.
+        let optional_element = Arc::new(
+            Type::primitive_type_builder("element", PhysicalType::FLOAT)
+                .with_repetition(Repetition::OPTIONAL)
+                .build()
+                .unwrap(),
+        );
+        assert!(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::VECTOR)
+                .with_vector_length(Some(3))
+                .with_fields(vec![optional_element])
+                .build()
+                .unwrap_err()
+                .to_string()
+                .contains("must be required")
+        );
+        let group_element = Arc::new(
+            Type::group_type_builder("element")
+                .with_repetition(Repetition::REQUIRED)
+                .with_fields(vec![element.clone()])
+                .build()
+                .unwrap(),
+        );
+        assert!(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::VECTOR)
+                .with_vector_length(Some(3))
+                .with_fields(vec![group_element])
+                .build()
+                .unwrap_err()
+                .to_string()
+                .contains("primitive field")
+        );
+
+        // vector_length is invalid without VECTOR repetition.
+        assert!(
+            Type::group_type_builder("list")
+                .with_repetition(Repetition::REQUIRED)
+                .with_vector_length(Some(3))
+                .with_fields(vec![element.clone()])
+                .build()
+                .unwrap_err()
+                .to_string()
+                .contains("can only be set on a VECTOR")
+        );
+
+        // The outer VECTOR logical group must contain the VECTOR list group.
+        let vector = Type::group_type_builder("v")
+            .with_repetition(Repetition::REQUIRED)
+            .with_logical_type(Some(LogicalType::Vector))
+            .with_fields(vec![Arc::new(list)])
+            .build()
+            .unwrap();
+        assert_eq!(
+            vector.get_basic_info().logical_type_ref(),
+            Some(&LogicalType::Vector)
+        );
+
+        // The canonical VECTOR logical type and group-level vector_length survive
+        // a Thrift schema round-trip.
+        let root = Type::group_type_builder("schema")
+            .with_fields(vec![Arc::new(vector.clone())])
+            .build()
+            .unwrap();
+        let roundtripped = roundtrip_schema(Arc::new(root)).unwrap();
+        assert_eq!(roundtripped.get_fields()[0].as_ref(), &vector);
+    }
+
+    #[test]
+    fn test_parquet_schema_from_array_rejects_zero_child_vector_group() {
+        let elements = vec![
+            SchemaElement {
+                r#type: None,
+                type_length: None,
+                repetition_type: None,
+                name: "schema",
+                num_children: Some(1),
+                converted_type: None,
+                scale: None,
+                precision: None,
+                field_id: None,
+                logical_type: None,
+                vector_length: None,
+            },
+            SchemaElement {
+                r#type: None,
+                type_length: None,
+                repetition_type: Some(Repetition::VECTOR),
+                name: "list",
+                num_children: Some(0),
+                converted_type: None,
+                scale: None,
+                precision: None,
+                field_id: None,
+                logical_type: None,
+                vector_length: Some(3),
+            },
+        ];
+        let err = parquet_schema_from_array(elements).unwrap_err().to_string();
+        assert!(
+            err.contains("one child named 'element'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -2518,6 +2882,7 @@ mod tests {
             precision: None,
             field_id: None,
             logical_type: None,
+            vector_length: None,
         }];
         let result = parquet_schema_from_array(elements);
         assert!(result.unwrap_err().to_string().contains("Integer overflow"));

--- a/parquet/src/schema/visitor.rs
+++ b/parquet/src/schema/visitor.rs
@@ -53,10 +53,7 @@ pub trait TypeVisitor<R, C> {
             Type::PrimitiveType { .. } => {
                 panic!("{list_type:?} is a list type and must be a group type")
             }
-            Type::GroupType {
-                basic_info: _,
-                fields,
-            } if fields.len() == 1 => {
+            Type::GroupType { fields, .. } if fields.len() == 1 => {
                 let list_item = fields.first().unwrap();
 
                 match list_item.as_ref() {
@@ -69,10 +66,7 @@ pub trait TypeVisitor<R, C> {
                             ))
                         }
                     }
-                    Type::GroupType {
-                        basic_info: _,
-                        fields,
-                    } => {
+                    Type::GroupType { fields, .. } => {
                         if fields.len() == 1
                             && list_item.name() != "array"
                             && list_item.name() != format!("{}_tuple", list_type.name())

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -190,20 +190,24 @@ impl<P: Iterator<Item = Page> + Send> PageReader for InMemoryPageReader<P> {
                 Page::DataPage { num_values, .. } => Ok(Some(PageMetadata {
                     num_rows: None,
                     num_levels: Some(*num_values as _),
+                    num_nulls: None,
                     is_dict: false,
                 })),
                 Page::DataPageV2 {
                     num_rows,
                     num_values,
+                    num_nulls,
                     ..
                 } => Ok(Some(PageMetadata {
                     num_rows: Some(*num_rows as _),
                     num_levels: Some(*num_values as _),
+                    num_nulls: Some(*num_nulls as _),
                     is_dict: false,
                 })),
                 Page::DictionaryPage { .. } => Ok(Some(PageMetadata {
                     num_rows: None,
                     num_levels: None,
+                    num_nulls: None,
                     is_dict: true,
                 })),
             }


### PR DESCRIPTION
Opt-in encoding of eligible top-level non-nullable `FixedSizeList` columns using the canonical 3-level Parquet VECTOR layout:

```text
required group <name> (VECTOR) {
  vector group list [N] {
    required <element-type> element;
  }
}
```

The middle group uses `FieldRepetitionType::VECTOR` (= 3) plus `SchemaElement.vector_length` (Thrift field id 11). It contributes no definition or repetition levels, so the element leaf is stored as a flat `rows * N` primitive stream.

Enabled via `WriterProperties::set_vector_encoding` (default off) and self-describing on read. Only a non-nullable top-level `FixedSizeList(child, N)` with `N > 0` and a non-nullable fixed-width primitive element qualifies; anything else falls back to LIST. Nested VECTOR schemas are rejected on read.

Pages stay vector-aligned and VECTOR pages must be dense. The reader validates row-group/page `num_values` against `num_rows * N`, rejects non-dense DataPageV2 pages, and validates skip paths too (falling back to reading a page when offset-index metadata is incomplete).

Statistics, page indexes, and bloom filters retain Parquet's element-level semantics over the flattened values.

VECTOR is not yet part of apache/parquet-format: files written with it are not readable by implementations that do not understand the repetition type.